### PR TITLE
add verbose labels

### DIFF
--- a/pkg/controller/auditlogging/auditlogging.go
+++ b/pkg/controller/auditlogging/auditlogging.go
@@ -41,7 +41,7 @@ func (r *ReconcileAuditLogging) updateStatus(instance *operatorv1alpha1.AuditLog
 	podList := &corev1.PodList{}
 	listOpts := []client.ListOption{
 		client.InNamespace(instance.Spec.InstanceNamespace),
-		client.MatchingLabels(res.LabelsForFluentd(instance.Name)),
+		client.MatchingLabels(res.LabelsForSelector(res.FluentdName, instance.Name)),
 	}
 	if err := r.client.List(context.TODO(), podList, listOpts...); err != nil {
 		reqLogger.Error(err, "Failed to list pods", "AuditLogging.Namespace", instance.Spec.InstanceNamespace, "AuditLogging.Name", instance.Name)
@@ -55,7 +55,7 @@ func (r *ReconcileAuditLogging) updateStatus(instance *operatorv1alpha1.AuditLog
 	// Get audit-policy-controller pod too
 	listOpts = []client.ListOption{
 		client.InNamespace(instance.Spec.InstanceNamespace),
-		client.MatchingLabels(res.LabelsForPolicyController(instance.Name)),
+		client.MatchingLabels(res.LabelsForSelector(res.AuditPolicyControllerDeploy, instance.Name)),
 	}
 	if err := r.client.List(context.TODO(), podList, listOpts...); err != nil {
 		reqLogger.Error(err, "Failed to list pods", "AuditLogging.Namespace", instance.Spec.InstanceNamespace, "AuditLogging.Name", instance.Name)

--- a/pkg/resources/containers.go
+++ b/pkg/resources/containers.go
@@ -39,6 +39,7 @@ const splunkConfigKey = "splunkHEC.conf"
 const qRadarConfigKey = "remoteSyslog.conf"
 const AuditLoggingCertName = "fluentd"
 const AuditPolicyControllerDeploy = "audit-policy-controller"
+const FluentdName = "fluentd"
 
 var trueVar = true
 var falseVar = false
@@ -198,7 +199,7 @@ var policyControllerMainContainer = corev1.Container{
 
 var fluentdMainContainer = corev1.Container{
 	Image:           "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64/fluentd:v1.6.2-rhc",
-	Name:            "fluentd",
+	Name:            FluentdName,
 	ImagePullPolicy: corev1.PullIfNotPresent,
 	VolumeMounts: []corev1.VolumeMount{
 		{

--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -30,13 +30,16 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	ver "github.com/ibm/ibm-auditlogging-operator/version"
 )
 
-const auditLoggingComponentName = "fluentd"
+const auditLoggingComponentName = "auditlogging_svc"
+const auditLoggingReleaseName = "auditlogging"
+const auditLoggingCrType = "auditlogging_cr"
 const clusterRoleSuffix = "-role"
 const clusterRoleBindingSuffix = "-rolebinding"
 const productName = "IBM Cloud Platform Common Services"
-const productVersion = "3.5.0.0"
 const productID = "AuditLogging_3.5.0.0_Apache_00000"
 const ServiceAcct = "-svcacct"
 const defaultClusterIssuer = "cs-ca-clusterissuer"
@@ -47,11 +50,11 @@ var commonVolumes = []corev1.Volume{}
 
 // BuildClusterRoleBinding returns a ClusterRoleBinding object
 func BuildClusterRoleBindingForPolicyController(instance *operatorv1alpha1.AuditLogging) *rbacv1.ClusterRoleBinding {
-	ls := LabelsForPolicyController(instance.Name)
+	metaLabels := LabelsForMetadata(AuditPolicyControllerDeploy)
 	rb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   AuditPolicyControllerDeploy + clusterRoleBindingSuffix,
-			Labels: ls,
+			Labels: metaLabels,
 		},
 		Subjects: []rbacv1.Subject{{
 			Kind:      "ServiceAccount",
@@ -69,11 +72,11 @@ func BuildClusterRoleBindingForPolicyController(instance *operatorv1alpha1.Audit
 
 // BuildClusterRole returns a ClusterRole object
 func BuildClusterRoleForPolicyController(instance *operatorv1alpha1.AuditLogging) *rbacv1.ClusterRole {
-	ls := LabelsForPolicyController(instance.Name)
+	metaLabels := LabelsForMetadata(AuditPolicyControllerDeploy)
 	cr := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   AuditPolicyControllerDeploy + clusterRoleSuffix,
-			Labels: ls,
+			Labels: metaLabels,
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -139,12 +142,12 @@ func BuildClusterRoleForPolicyController(instance *operatorv1alpha1.AuditLogging
 
 // BuildRoleBindingForFluentd returns a RoleBinding object for fluentd
 func BuildRoleBindingForFluentd(instance *operatorv1alpha1.AuditLogging) *rbacv1.RoleBinding {
-	ls := LabelsForFluentd(instance.Name)
+	metaLabels := LabelsForMetadata(FluentdName)
 	rb := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      FluentdDaemonSetName + clusterRoleBindingSuffix,
 			Namespace: instance.Spec.InstanceNamespace,
-			Labels:    ls,
+			Labels:    metaLabels,
 		},
 		Subjects: []rbacv1.Subject{{
 			APIGroup:  "",
@@ -163,12 +166,12 @@ func BuildRoleBindingForFluentd(instance *operatorv1alpha1.AuditLogging) *rbacv1
 
 // BuildRoleForFluentd returns a Role object for fluentd
 func BuildRoleForFluentd(instance *operatorv1alpha1.AuditLogging) *rbacv1.Role {
-	ls := LabelsForFluentd(instance.Name)
+	metaLabels := LabelsForMetadata(FluentdName)
 	cr := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      FluentdDaemonSetName + clusterRoleSuffix,
 			Namespace: instance.Spec.InstanceNamespace,
-			Labels:    ls,
+			Labels:    metaLabels,
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -185,7 +188,7 @@ func BuildRoleForFluentd(instance *operatorv1alpha1.AuditLogging) *rbacv1.Role {
 // BuildConfigMap returns a ConfigMap object
 func BuildConfigMap(instance *operatorv1alpha1.AuditLogging, name string) (*corev1.ConfigMap, error) {
 	reqLogger := log.WithValues("ConfigMap.Namespace", instance.Spec.InstanceNamespace, "ConfigMap.Name", name)
-	ls := LabelsForFluentd(instance.Name)
+	metaLabels := LabelsForMetadata(FluentdName)
 	dataMap := make(map[string]string)
 	var err error
 	switch name {
@@ -241,7 +244,7 @@ func BuildConfigMap(instance *operatorv1alpha1.AuditLogging, name string) (*core
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Labels:    ls,
+			Labels:    metaLabels,
 			Namespace: instance.Spec.InstanceNamespace,
 		},
 		Data: dataMap,
@@ -252,8 +255,11 @@ func BuildConfigMap(instance *operatorv1alpha1.AuditLogging, name string) (*core
 // BuildDeploymentForPolicyController returns a Deployment object
 func BuildDeploymentForPolicyController(instance *operatorv1alpha1.AuditLogging) *appsv1.Deployment {
 	reqLogger := log.WithValues("deploymentForPolicyController", "Entry", "instance.Name", instance.Name)
-	ls := LabelsForPolicyController(instance.Name)
+	metaLabels := LabelsForMetadata(AuditPolicyControllerDeploy)
+	selectorLabels := LabelsForSelector(AuditPolicyControllerDeploy, instance.Name)
+	podLabels := LabelsForPodMetadata(AuditPolicyControllerDeploy, instance.Name)
 	annotations := annotationsForMetering(AuditPolicyControllerDeploy)
+
 	if instance.Spec.PolicyController.ImageRegistry != "" && instance.Spec.PolicyController.ImageTagPostfix != "" {
 		policyControllerMainContainer.Image = instance.Spec.PolicyController.ImageRegistry +
 			"/audit-policy-controller:" +
@@ -288,15 +294,16 @@ func BuildDeploymentForPolicyController(instance *operatorv1alpha1.AuditLogging)
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      AuditPolicyControllerDeploy,
 			Namespace: instance.Spec.InstanceNamespace,
+			Labels:    metaLabels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: ls,
+				MatchLabels: selectorLabels,
 			},
 			Replicas: &replicas,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      ls,
+					Labels:      podLabels,
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
@@ -324,7 +331,7 @@ func BuildDeploymentForPolicyController(instance *operatorv1alpha1.AuditLogging)
 
 // BuildCertsForAuditLogging returns a Certificate object
 func BuildCertsForAuditLogging(instance *operatorv1alpha1.AuditLogging, issuer string) *certmgr.Certificate {
-	ls := LabelsForFluentd(instance.Name)
+	metaLabels := LabelsForMetadata(FluentdName)
 	var clusterIssuer string
 	if issuer != "" {
 		clusterIssuer = issuer
@@ -335,7 +342,7 @@ func BuildCertsForAuditLogging(instance *operatorv1alpha1.AuditLogging, issuer s
 	certificate := &certmgr.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      AuditLoggingCertName,
-			Labels:    ls,
+			Labels:    metaLabels,
 			Namespace: instance.Spec.InstanceNamespace,
 		},
 		Spec: certmgr.CertificateSpec{
@@ -353,10 +360,13 @@ func BuildCertsForAuditLogging(instance *operatorv1alpha1.AuditLogging, issuer s
 // BuildDaemonForFluentd returns a Daemonset object
 func BuildDaemonForFluentd(instance *operatorv1alpha1.AuditLogging) *appsv1.DaemonSet {
 	reqLogger := log.WithValues("dameonForFluentd", "Entry", "instance.Name", instance.Name)
-	ls := LabelsForFluentd(instance.Name)
-	annotations := annotationsForMetering(FluentdDaemonSetName)
+	metaLabels := LabelsForMetadata(FluentdName)
+	selectorLabels := LabelsForSelector(FluentdName, instance.Name)
+	podLabels := LabelsForPodMetadata(FluentdName, instance.Name)
+	annotations := annotationsForMetering(FluentdName)
 	commonVolumes = BuildCommonVolumes(instance)
 	fluentdMainContainer.VolumeMounts = BuildCommonVolumeMounts(instance)
+
 	if instance.Spec.Fluentd.ImageRegistry != "" && instance.Spec.Fluentd.ImageTagPostfix != "" {
 		fluentdMainContainer.Image = instance.Spec.Fluentd.ImageRegistry + "/fluentd:" + instance.Spec.Fluentd.ImageTagPostfix
 	}
@@ -377,10 +387,11 @@ func BuildDaemonForFluentd(instance *operatorv1alpha1.AuditLogging) *appsv1.Daem
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      FluentdDaemonSetName,
 			Namespace: instance.Spec.InstanceNamespace,
+			Labels:    metaLabels,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: ls,
+				MatchLabels: selectorLabels,
 			},
 			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 				Type: appsv1.RollingUpdateDaemonSetStrategyType,
@@ -394,7 +405,7 @@ func BuildDaemonForFluentd(instance *operatorv1alpha1.AuditLogging) *appsv1.Daem
 			MinReadySeconds: 5,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      ls,
+					Labels:      podLabels,
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
@@ -624,22 +635,34 @@ func GetPodNames(pods []corev1.Pod) []string {
 }
 
 //IBMDEV
-func LabelsForPolicyController(crName string) map[string]string {
-	return map[string]string{"app": AuditPolicyControllerDeploy, "auditlogging_cr": crName}
+func LabelsForMetadata(name string) map[string]string {
+	return map[string]string{"app": name, "app.kubernetes.io/name": name, "app.kubernetes.io/component": auditLoggingComponentName,
+		"app.kubernetes.io/managed-by": "operator", "app.kubernetes.io/instance": auditLoggingReleaseName, "release": auditLoggingReleaseName}
 }
 
 //IBMDEV
-func LabelsForFluentd(crName string) map[string]string {
-	return map[string]string{"app": auditLoggingComponentName, "auditlogging_cr": crName}
+func LabelsForSelector(name string, crName string) map[string]string {
+	return map[string]string{"app": name, "component": auditLoggingComponentName, auditLoggingCrType: crName}
 }
 
+//IBMDEV
+func LabelsForPodMetadata(deploymentName string, crName string) map[string]string {
+	podLabels := LabelsForMetadata(deploymentName)
+	selectorLabels := LabelsForSelector(deploymentName, crName)
+	for key, value := range selectorLabels {
+		podLabels[key] = value
+	}
+	return podLabels
+}
+
+//IBMDEV
 func annotationsForMetering(deploymentName string) map[string]string {
 	annotations := map[string]string{
 		"productName":    productName,
-		"productVersion": productVersion,
+		"productVersion": ver.Version,
 		"productID":      productID,
 	}
-	if deploymentName == FluentdDaemonSetName {
+	if deploymentName == FluentdName {
 		annotations["seccomp.security.alpha.kubernetes.io/pod"] = "docker/default"
 	}
 	return annotations

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 var (
-	Version = "0.0.1"
+	Version = "3.5.0"
 )


### PR DESCRIPTION
Testing:

```
Name:           audit-logging-fluentd-ds
Selector:       app=fluentd,auditlogging_cr=example-auditlogging,component=auditlogging_svc
Node-Selector:  <none>
Labels:         app=fluentd
                app.kubernetes.io/component=auditlogging_svc
                app.kubernetes.io/instance=auditlogging
                app.kubernetes.io/managed-by=operator
                app.kubernetes.io/name=fluentd
                release=auditlogging
Annotations:    deprecated.daemonset.template.generation: 1
Desired Number of Nodes Scheduled: 3
Current Number of Nodes Scheduled: 3
Number of Nodes Scheduled with Up-to-date Pods: 3
Number of Nodes Scheduled with Available Pods: 3
Number of Nodes Misscheduled: 0
Pods Status:  3 Running / 0 Waiting / 0 Succeeded / 0 Failed
Pod Template:
  Labels:           app=fluentd
                    app.kubernetes.io/component=auditlogging_svc
                    app.kubernetes.io/instance=auditlogging
                    app.kubernetes.io/managed-by=operator
                    app.kubernetes.io/name=fluentd
                    auditlogging_cr=example-auditlogging
                    component=auditlogging_svc
                    release=auditlogging
  Annotations:      productID: AuditLogging_3.5.0.0_Apache_00000
                    productName: IBM Cloud Platform Common Services
                    productVersion: 3.5.0
                    seccomp.security.alpha.kubernetes.io/pod: docker/default