### PR TITLE
instanceNamespace cannot be empty, but enabled can be empty

### DIFF
--- a/deploy/crds/operator.ibm.com_auditloggings_crd.yaml
+++ b/deploy/crds/operator.ibm.com_auditloggings_crd.yaml
@@ -46,8 +46,6 @@ spec:
                   type: string
                 pullPolicy:
                   type: string
-              required:
-              - enabled
               type: object
             instanceNamespace:
               type: string
@@ -74,6 +72,8 @@ spec:
                 verbosity:
                   type: string
               type: object
+          required:
+          - instanceNamespace
           type: object
         status:
           description: AuditLoggingStatus defines the observed state of AuditLogging

--- a/pkg/apis/operator/v1alpha1/auditlogging_types.go
+++ b/pkg/apis/operator/v1alpha1/auditlogging_types.go
@@ -31,12 +31,12 @@ type AuditLoggingSpec struct {
 	OperatorVersion   string                           `json:"operatorVersion,omitempty"`
 	Fluentd           AuditLoggingSpecFluentd          `json:"fluentd,omitempty"`
 	PolicyController  AuditLoggingSpecPolicyController `json:"policyController,omitempty"`
-	InstanceNamespace string                           `json:"instanceNamespace,omitempty"`
+	InstanceNamespace string                           `json:"instanceNamespace"`
 }
 
 // AuditLoggingSpecFluentd defines the desired state of Fluentd
 type AuditLoggingSpecFluentd struct {
-	EnableAuditLoggingForwarding bool   `json:"enabled"`
+	EnableAuditLoggingForwarding bool   `json:"enabled,omitempty"`
 	ImageRegistry                string `json:"imageRegistry,omitempty"`
 	ImageTagPostfix              string `json:"imageTagPostfix,omitempty"`
 	PullPolicy                   string `json:"pullPolicy,omitempty"`

--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -190,11 +190,7 @@ func BuildConfigMap(instance *operatorv1alpha1.AuditLogging, name string) (*core
 	var err error
 	switch name {
 	case FluentdDaemonSetName + "-" + ConfigName:
-		if instance.Spec.InstanceNamespace != "" {
-			dataMap[enableAuditLogForwardKey] = strconv.FormatBool(instance.Spec.Fluentd.EnableAuditLoggingForwarding)
-		} else {
-			dataMap[enableAuditLogForwardKey] = "false"
-		}
+		dataMap[enableAuditLogForwardKey] = strconv.FormatBool(instance.Spec.Fluentd.EnableAuditLoggingForwarding)
 		type Data struct {
 			Value string `yaml:"fluent.conf"`
 		}


### PR DESCRIPTION
- user could have not set instanceNamespace and operator would break
- enabled will always default to false and we dont require user to set it at creation unless they want to