### PR TITLE
remove long comments in cm

### DIFF
--- a/common/Makefile.common.mk
+++ b/common/Makefile.common.mk
@@ -61,7 +61,7 @@ lint-copyright-banner:
 		${XARGS} common/scripts/lint_copyright_banner.sh
 
 lint-go:
-	# @${FINDFILES} -name '*.go' \( ! \( -name '*.gen.go' -o -name '*.pb.go' \) \) -print0 | ${XARGS} common/scripts/lint_go.sh
+	@${FINDFILES} -name '*.go' \( ! \( -name '*.gen.go' -o -name '*.pb.go' \) \) -print0 | ${XARGS} common/scripts/lint_go.sh
 
 lint-python:
 	@${FINDFILES} -name '*.py' \( ! \( -name '*_pb2.py' \) \) -print0 | ${XARGS} autopep8 --max-line-length 160 --exit-code -d

--- a/pkg/controller/auditlogging/auditlogging_controller.go
+++ b/pkg/controller/auditlogging/auditlogging_controller.go
@@ -198,7 +198,7 @@ func (r *ReconcileAuditLogging) Reconcile(request reconcile.Request) (reconcile.
 	}
 
 	reqLogger.Info("Reconciliation successful!", "Name", instance.Name)
-	// since we updated the status in the Metering CR, sleep 5 seconds to allow the CR to be refreshed.
+	// since we updated the status in the Audit Logging CR, sleep 5 seconds to allow the CR to be refreshed.
 	time.Sleep(5 * time.Second)
 
 	return reconcile.Result{}, nil

--- a/pkg/controller/auditlogging/auditlogging_controller.go
+++ b/pkg/controller/auditlogging/auditlogging_controller.go
@@ -19,6 +19,7 @@ package auditlogging
 import (
 	"context"
 	"reflect"
+	"time"
 
 	operatorv1alpha1 "github.com/ibm/ibm-auditlogging-operator/pkg/apis/operator/v1alpha1"
 	certmgr "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
@@ -197,5 +198,8 @@ func (r *ReconcileAuditLogging) Reconcile(request reconcile.Request) (reconcile.
 	}
 
 	reqLogger.Info("Reconciliation successful!", "Name", instance.Name)
+	// since we updated the status in the Metering CR, sleep 5 seconds to allow the CR to be refreshed.
+	time.Sleep(5 * time.Second)
+
 	return reconcile.Result{}, nil
 }

--- a/pkg/resources/containers.go
+++ b/pkg/resources/containers.go
@@ -89,11 +89,9 @@ var fluentdMainConfigData = `
 fluent.conf: |-
   # Input plugins
   @include /fluentd/etc/source.conf
-  # Output plugins
-  # Only use one output plugin conf file at a time. Comment or remove other files 
-  # To forward audit logs to QRadar, uncommnet following line, add QRadar server information in the 'audit-logging-fluentd-ds-remote-syslog-config' ConfigMap and restart the 'audit-logging-fluentd-ds-*' pods
+
+  # Output plugins (Only use one output plugin conf file at a time. Comment or remove other files)
   #@include /fluentd/etc/remoteSyslog.conf
-  #To forward audit logs to Splunk over HTTPS, uncomment following line, add Splunk server information in the 'audit-logging-fluentd-ds-splunk-hec-config' ConfigMap and restart the 'audit-logging-fluentd-ds-*' pods
   #@include /fluentd/etc/splunkHEC.conf
 `
 


### PR DESCRIPTION
linter was complaining about the long lines in the fluentd cm

testing uncommenting qradar output plugin:

```
➜  ibm-auditlogging-operator git:(lint) ✗ k describe cm audit-logging-fluentd-ds-config
Name:         audit-logging-fluentd-ds-config
Namespace:    ibm-common-services
Labels:       app=fluentd
              auditlogging_cr=example-auditlogging
Annotations:  <none>

Data
====
ENABLE_AUDIT_LOGGING_FORWARDING:
----
true
fluent.conf:
----
# Input plugins
@include /fluentd/etc/source.conf

# Output plugins (Only use one output plugin conf file at a time. Comment or remove other files)
@include /fluentd/etc/remoteSyslog.conf
#@include /fluentd/etc/splunkHEC.conf
Events:  <none>

➜  ibm-auditlogging-operator git:(lint) ✗ k logs audit-logging-fluentd-ds-qvbdz
2020-03-05 20:51:01 +0000 [info]: parsing config file is succeeded path="/fluentd/etc/fluent.conf"
2020-03-05 20:51:01 +0000 [info]: using configuration file: <ROOT>
  <source>
    @type systemd
    @id input_systemd_icp
    @log_level "info"
    tag "icp-audit"
    path "/var/log/journal"
    matches [{ "SYSLOG_IDENTIFIER": "icp-audit" }]
    read_from_head true
    <storage>
      @type "local"
      persistent true
      path "/icp-audit"
    </storage>
    <entry>
      fields_strip_underscores true
      fields_lowercase true
    </entry>
  </source>
  <filter icp-audit>
    @type parser
    format json
    key_name "message"
    reserve_data true
    <parse>
      @type json
    </parse>
  </filter>
  <match icp-audit>
    @type copy
    <store>
      @type "remote_syslog"
      host "QRADAR_SERVER_HOSTNAME"
      port QRADAR_PORT_FOR_icp-audit
      hostname "QRADAR_LOG_SOURCE_IDENTIFIER_FOR_icp-audit"
      protocol tcp
      tls true
      ca_file "/fluentd/etc/tls/qradar.crt"
      packet_size 4096
      program "fluentd"
      <format>
        @type "single_value"
        message_key "message"
      </format>
    </store>
  </match>
</ROOT>
2020-03-05 20:51:01 +0000 [info]: starting fluentd-1.6.2 pid=1 ruby="2.3.8"
2020-03-05 20:51:01 +0000 [info]: spawn command to main:  cmdline=["/usr/local/rvm/rubies/ruby-2.3.8/bin/ruby", "-Eascii-8bit:ascii-8bit", "/fluentd/vendor/bundle/ruby/2.3.0/bin/fluentd", "-c", "/fluentd/etc/fluent.conf", "--under-supervisor"]
2020-03-05 20:51:05 +0000 [info]: gem 'fluent-plugin-elasticsearch' version '3.5.2'
2020-03-05 20:51:05 +0000 [info]: gem 'fluent-plugin-kubernetes-objects' version '1.1.1'
2020-03-05 20:51:05 +0000 [info]: gem 'fluent-plugin-remote_syslog' version '1.0.0'
2020-03-05 20:51:05 +0000 [info]: gem 'fluent-plugin-rewrite-tag-filter' version '2.2.0'
2020-03-05 20:51:05 +0000 [info]: gem 'fluent-plugin-splunk-hec' version '1.1.2'
2020-03-05 20:51:05 +0000 [info]: gem 'fluent-plugin-systemd' version '1.0.2'
2020-03-05 20:51:05 +0000 [info]: gem 'fluentd' version '1.6.2'
2020-03-05 20:51:05 +0000 [info]: adding filter pattern="icp-audit" type="parser"
2020-03-05 20:51:05 +0000 [info]: adding match pattern="icp-audit" type="copy"
2020-03-05 20:51:05 +0000 [info]: adding source type="systemd"
2020-03-05 20:51:05 +0000 [info]: #0 starting fluentd worker pid=20 ppid=1 worker=0
2020-03-05 20:51:05 +0000 [info]: #0 fluentd worker is now running worker=0