### PR TITLE
using correct ubi arch image for z and power

### DIFF
--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -4,7 +4,7 @@ RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/r
 
 RUN chmod +x /qemu-ppc64le-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1-398
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:c3b4979b758ca7d4d790d418aa2f3010ebe9ad1ffcf3b4092e47ee03bf447823
 ARG VCS_REF
 ARG VCS_URL
 

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -4,7 +4,7 @@ RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/rel
 
 RUN chmod +x /qemu-s390x-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1-398
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:d61900307c7441a2065c102a4e6a3d55050027b6f1fd301ec691dd8dd032411a
 ARG VCS_REF
 ARG VCS_URL
 


### PR DESCRIPTION
We were using the amd UBI image for s390 and ppc64le. 