### PR TITLE
remove unused args 

### DIFF
--- a/deploy/crds/operator.ibm.com_auditloggings_crd.yaml
+++ b/deploy/crds/operator.ibm.com_auditloggings_crd.yaml
@@ -47,18 +47,10 @@ spec:
                 pullPolicy:
                   type: string
               type: object
-            operatorVersion:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "operator-sdk generate k8s" to regenerate code after
-                modifying this file Add custom validation using kubebuilder tags:
-                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-              type: string
             policyController:
               description: AuditLoggingSpecPolicyController defines the policy controller
                 configuration in the the audit logging spec
               properties:
-                duration:
-                  type: string
                 frequency:
                   type: string
                 imageRegistry:

--- a/deploy/crds/operator.ibm.com_v1alpha1_auditlogging_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_auditlogging_cr.yaml
@@ -3,7 +3,6 @@ kind: AuditLogging
 metadata:
   name: example-auditlogging
 spec:
-  operatorVersion: 3.5.0
   fluentd:
     enabled: true
     imageRegistry: hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64/

--- a/deploy/olm-catalog/ibm-auditlogging-operator/3.5.0/ibm-auditlogging-operator.v3.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-auditlogging-operator/3.5.0/ibm-auditlogging-operator.v3.5.0.clusterserviceversion.yaml
@@ -18,7 +18,6 @@ metadata:
               "journalPath": "/var/log/journal",
               "pullPolicy": "IfNotPresent"
             },
-            "operatorVersion": "3.5.0",
             "policyController": {
               "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64/",
               "imageTag": "3.4.0",

--- a/deploy/olm-catalog/ibm-auditlogging-operator/3.5.0/operator.ibm.com_auditloggings_crd.yaml
+++ b/deploy/olm-catalog/ibm-auditlogging-operator/3.5.0/operator.ibm.com_auditloggings_crd.yaml
@@ -47,18 +47,10 @@ spec:
                 pullPolicy:
                   type: string
               type: object
-            operatorVersion:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "operator-sdk generate k8s" to regenerate code after
-                modifying this file Add custom validation using kubebuilder tags:
-                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-              type: string
             policyController:
               description: AuditLoggingSpecPolicyController defines the policy controller
                 configuration in the the audit logging spec
               properties:
-                duration:
-                  type: string
                 frequency:
                   type: string
                 imageRegistry:

--- a/pkg/apis/operator/v1alpha1/auditlogging_types.go
+++ b/pkg/apis/operator/v1alpha1/auditlogging_types.go
@@ -28,7 +28,6 @@ type AuditLoggingSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
-	OperatorVersion  string                           `json:"operatorVersion,omitempty"`
 	Fluentd          AuditLoggingSpecFluentd          `json:"fluentd,omitempty"`
 	PolicyController AuditLoggingSpecPolicyController `json:"policyController,omitempty"`
 }
@@ -50,7 +49,6 @@ type AuditLoggingSpecPolicyController struct {
 	PullPolicy    string `json:"pullPolicy,omitempty"`
 	Verbosity     string `json:"verbosity,omitempty"`
 	Frequency     string `json:"frequency,omitempty"`
-	Duration      string `json:"duration,omitempty"`
 }
 
 // AuditLoggingStatus defines the observed state of AuditLogging

--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -431,18 +431,8 @@ func BuildDaemonForFluentd(instance *operatorv1alpha1.AuditLogging) *appsv1.Daem
 					ServiceAccountName:            FluentdDaemonSetName + ServiceAcct,
 					TerminationGracePeriodSeconds: &seconds30,
 					// NodeSelector:                  {},
-					Tolerations: []corev1.Toleration{
-						{
-							Key:      "dedicated",
-							Operator: corev1.TolerationOpExists,
-							Effect:   corev1.TaintEffectNoSchedule,
-						},
-						{
-							Key:      "CriticalAddonsOnly",
-							Operator: corev1.TolerationOpExists,
-						},
-					},
-					Volumes: commonVolumes,
+					Tolerations: commonTolerations,
+					Volumes:     commonVolumes,
 					Containers: []corev1.Container{
 						fluentdMainContainer,
 					},

--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -289,10 +289,8 @@ func BuildDeploymentForPolicyController(instance *operatorv1alpha1.AuditLogging)
 	var args = make([]string, 0)
 	if instance.Spec.PolicyController.Verbosity != "" {
 		args = append(args, "--v="+instance.Spec.PolicyController.Verbosity)
-	}
-	if instance.Spec.PolicyController.Duration != "" {
-		args = append(args, "--default-duration="+instance.Spec.PolicyController.Duration)
-		reqLogger.Info("Test", "Duration", instance.Spec.PolicyController.Duration)
+	} else {
+		args = append(args, "--v=0")
 	}
 	if instance.Spec.PolicyController.Frequency != "" {
 		args = append(args, "--update-frequency="+instance.Spec.PolicyController.Frequency)


### PR DESCRIPTION
- audit policy controller doesnt use `default-duration`
- operator doesnt use `operatorVersion` for any logic

```
docker run -it hyc-cloud-private-integration-docker-local.artifactory.swg-devops.com/ibmcom/audit-policy-controller-amd64:3.3.1 --default-duration=5 bash
flag provided but not defined: -default-duration
Usage of /usr/bin/audit-policy-controller:
  -alsologtostderr
    	log to standard error as well as files
  -cluster-name string
    	Name of the cluster (default "mcm-managed-cluster")
  -kubeconfig string
    	Paths to a kubeconfig. Only required if out-of-cluster.
  -log_backtrace_at value
    	when logging hits line file:N, emit a stack trace
  -log_dir string
    	If non-empty, write log files in this directory
  -logtostderr
    	log to standard error instead of files
  -master string
    	The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.
  -metrics-addr string
    	The address the metric endpoint binds to (default ":8080")
  -parent-event string
    	to also send status events on parent policy. options are: yes/no/ifpresent (default "ifpresent")
  -prometheus-address string
    	The address where prometheus posts the controller metrics (default ":8090")
  -restart-orphan-pods
    	Pods that are not part of a controller
  -stderrthreshold value
    	logs at or above this threshold go to stderr
  -update-frequency uint
    	The status update frequency (in seconds) of a mutation policy (default 10)
  -v value
    	log level for V logs
  -vmodule value
    	comma-separated list of pattern=N settings for file-filtered logging
  -watch-ns string
    	Watched Kubernetes namespace (default "default")