### PR TITLE
missing policy controller resources

### DIFF
--- a/pkg/resources/containers.go
+++ b/pkg/resources/containers.go
@@ -53,8 +53,12 @@ var rootUser = int64(0)
 var user100 = int64(100)
 var replicas = int32(1)
 var cpu25 = resource.NewMilliQuantity(25, resource.DecimalSI)          // 25m
+var cpu100 = resource.NewMilliQuantity(100, resource.DecimalSI)        // 100m
+var cpu200 = resource.NewMilliQuantity(200, resource.DecimalSI)        // 200m
 var cpu300 = resource.NewMilliQuantity(300, resource.DecimalSI)        // 300m
 var memory100 = resource.NewQuantity(100*1024*1024, resource.BinarySI) // 100Mi
+var memory150 = resource.NewQuantity(150*1024*1024, resource.BinarySI) // 150Mi
+var memory300 = resource.NewQuantity(300*1024*1024, resource.BinarySI) // 300Mi
 var memory400 = resource.NewQuantity(400*1024*1024, resource.BinarySI) // 400Mi
 
 var commonCapabilities = corev1.Capabilities{
@@ -197,6 +201,14 @@ var policyControllerMainContainer = corev1.Container{
 		},
 		InitialDelaySeconds: 10,
 		TimeoutSeconds:      2,
+	},
+	Resources: corev1.ResourceRequirements{
+		Limits: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceCPU:    *cpu200,
+			corev1.ResourceMemory: *memory300},
+		Requests: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceCPU:    *cpu100,
+			corev1.ResourceMemory: *memory150},
 	},
 	SecurityContext: &policyControllerSecurityContext,
 }


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/audit-logging-chart/blob/master/stable/audit-logging/templates/audit-policy-controller-deployment.yaml#L71

```
➜  ibm-auditlogging-operator git:(resources) ✗ k describe deploy audit-policy-controller
Name:                   audit-policy-controller
Namespace:              ibm-common-services
CreationTimestamp:      Tue, 17 Mar 2020 10:58:17 -0500
Labels:                 app=audit-policy-controller
                        app.kubernetes.io/component=common-audit-logging
                        app.kubernetes.io/instance=common-audit-logging
                        app.kubernetes.io/managed-by=operator
                        app.kubernetes.io/name=audit-policy-controller
                        release=common-audit-logging
Annotations:            deployment.kubernetes.io/revision: 1
Selector:               app=audit-policy-controller,auditlogging_cr=example-auditlogging,component=common-audit-logging
Replicas:               1 desired | 1 updated | 1 total | 1 available | 0 unavailable
StrategyType:           RollingUpdate
MinReadySeconds:        0
RollingUpdateStrategy:  25% max unavailable, 25% max surge
Pod Template:
  Labels:           app=audit-policy-controller
                    app.kubernetes.io/component=common-audit-logging
                    app.kubernetes.io/instance=common-audit-logging
                    app.kubernetes.io/managed-by=operator
                    app.kubernetes.io/name=audit-policy-controller
                    auditlogging_cr=example-auditlogging
                    component=common-audit-logging
                    release=common-audit-logging
  Annotations:      productID: 068a62892a1e4db39641342e592daa25
                    productMetric: FREE
                    productName: IBM Cloud Platform Common Services
                    productVersion: 3.3.0
  Service Account:  audit-policy-controller-svcacct
  Containers:
   audit-policy-controller:
    Image:      hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64/audit-policy-controller:3.4.0
    Port:       <none>
    Host Port:  <none>
    Args:
      --v=0
    Limits:
      cpu:     200m
      memory:  300Mi
    Requests:
      cpu:        100m
      memory:     150Mi
    Liveness:     exec [sh -c pgrep audit-policy -l] delay=30s timeout=5s period=10s #success=1 #failure=3
    Readiness:    exec [sh -c exec echo start audit-policy-controller] delay=10s timeout=2s period=10s #success=1 #failure=3
    Environment:  <none>
    Mounts:
      /tmp from tmp (rw)
  Volumes:
   tmp:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:
    SizeLimit:  <unset>
Conditions:
  Type           Status  Reason
  ----           ------  ------
  Progressing    True    NewReplicaSetAvailable
  Available      True    MinimumReplicasAvailable
OldReplicaSets:  <none>
NewReplicaSet:   audit-policy-controller-7c86675486 (1/1 replicas created)
Events:
  Type    Reason             Age    From                   Message
  ----    ------             ----   ----                   -------
  Normal  ScalingReplicaSet  2m48s  deployment-controller  Scaled up replica set audit-policy-controller-7c86675486 to 1
```

```
➜  ibm-auditlogging-operator git:(resources) ✗ k get po | grep audit
audit-log-test-5d984967dd-5b9kv                           2/2     Running                      0          15m
audit-logging-fluentd-ds-hrndx                            1/1     Running                      0          3m15s
audit-logging-fluentd-ds-sr82v                            1/1     Running                      0          3m15s
audit-policy-controller-7c86675486-fmcmb                  1/1     Running                      0          2m10s
ibm-auditlogging-operator-6f4f68cc94-d4vh9                1/1     Running                      0          3m49s
➜  ibm-auditlogging-operator git:(resources) ✗ k logs audit-policy-controller-7c86675486-fmcmb
I0317 15:59:33.073644       1 main.go:49] setting up client for manager
I0317 15:59:33.075795       1 main.go:57] setting up manager
I0317 15:59:33.469019       1 main.go:64] Registering Components.
I0317 15:59:33.469053       1 main.go:67] setting up scheme
I0317 15:59:33.469313       1 main.go:74] Setting up controller
I0317 15:59:33.469347       1 auditpolicy_controller.go:180] adding audit policy controller to mgr
I0317 15:59:33.479671       1 main.go:80] setting up webhooks
In printMap for AuditPolicy:  0
Waiting for policies to be available for processing for Audit...
I0317 15:59:33.481869       1 auditpolicy_controller.go:160] initialize audit policy controller
I0317 15:59:33.481918       1 main.go:94] Starting the Cmd.
I0317 15:59:33.481991       1 auditpolicy_controller.go:280] In PeriodicallyExecGRCPolicies for AuditPolicy
In printMap for AuditPolicy:  0
Waiting for policies to be available for processing for Audit...
In printMap for AuditPolicy:  0
Waiting for policies to be available for processing for Audit...
In printMap for AuditPolicy:  0
Waiting for policies to be available for processing for Audit...
In printMap for AuditPolicy:  0
Waiting for policies to be available for processing for Audit...
In printMap for AuditPolicy:  0
Waiting for policies to be available for processing for Audit...
In printMap for AuditPolicy:  0
Waiting for policies to be available for processing for Audit...
In printMap for AuditPolicy:  0
Waiting for policies to be available for processing for Audit...
In printMap for AuditPolicy:  0
Waiting for policies to be available for processing for Audit...
In printMap for AuditPolicy:  0
Waiting for policies to be available for processing for Audit...
In printMap for AuditPolicy:  0
Waiting for policies to be available for processing for Audit...
In printMap for AuditPolicy:  0
Waiting for policies to be available for processing for Audit...
In printMap for AuditPolicy:  0
Waiting for policies to be available for processing for Audit...
```