### PR TITLE
updated KC link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The predefined SecurityContextConstraints (SCC) `privileged` and `anyuid` are be
 
 ## Documentation
 
-For installation and configuration, see [IBM Knowledge Center link].
+For installation and configuration, see [IBM Knowledge Center link](http://ibm.biz/cpcsdocs).
 
 ## Developer guide
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The predefined SecurityContextConstraints (SCC) `privileged` and `anyuid` are be
 
 ## Documentation
 
-For installation and configuration, see [IBM Knowledge Center link](http://ibm.biz/cpcsdocs).
+For installation and configuration, see the [IBM Cloud Platform Common Services documentation](http://ibm.biz/cpcsdocs).
 
 ## Developer guide
 


### PR DESCRIPTION
In the Documentation section, the link to KC was not coded.