### PR TITLE
run policy controller and operator as restricted

### DIFF
--- a/deploy/olm-catalog/ibm-auditlogging-operator/3.6.0/ibm-auditlogging-operator.v3.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-auditlogging-operator/3.6.0/ibm-auditlogging-operator.v3.6.0.clusterserviceversion.yaml
@@ -306,6 +306,7 @@ spec:
                 productID: "068a62892a1e4db39641342e592daa25"
                 productVersion: "3.3.0"
                 productMetric: FREE
+                openshift.io/scc: restricted
               labels:
                 name: ibm-auditlogging-operator
             spec:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,6 +16,7 @@ spec:
         productID: "068a62892a1e4db39641342e592daa25"
         productVersion: "3.3.0"
         productMetric: FREE
+        openshift.io/scc: restricted
     spec:
       serviceAccountName: ibm-auditlogging-operator
       containers:

--- a/pkg/resources/containers.go
+++ b/pkg/resources/containers.go
@@ -60,7 +60,6 @@ const defaultHTTPPort = 9880
 var trueVar = true
 var falseVar = false
 var rootUser = int64(0)
-var user100 = int64(100)
 var replicas = int32(1)
 var cpu25 = resource.NewMilliQuantity(25, resource.DecimalSI)          // 25m
 var cpu100 = resource.NewMilliQuantity(100, resource.DecimalSI)        // 100m
@@ -90,7 +89,6 @@ var policyControllerSecurityContext = corev1.SecurityContext{
 	Privileged:               &falseVar,
 	ReadOnlyRootFilesystem:   &trueVar,
 	RunAsNonRoot:             &trueVar,
-	RunAsUser:                &user100,
 	Capabilities:             &commonCapabilities,
 }
 

--- a/pkg/resources/rbac.go
+++ b/pkg/resources/rbac.go
@@ -125,7 +125,7 @@ func BuildClusterRole(instance *operatorv1alpha1.AuditLogging) *rbacv1.ClusterRo
 				Verbs:         []string{"use"},
 				APIGroups:     []string{"security.openshift.io"},
 				Resources:     []string{"securitycontextconstraints"},
-				ResourceNames: []string{"anyuid"},
+				ResourceNames: []string{"restricted"},
 			},
 		},
 	}

--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -705,6 +705,9 @@ func annotationsForMetering(deploymentName string) map[string]string {
 	if deploymentName == FluentdName {
 		annotations["seccomp.security.alpha.kubernetes.io/pod"] = "docker/default"
 		annotations["clusterhealth.ibm.com/dependencies"] = "cert-manager"
+		annotations["openshift.io/scc"] = "privileged"
+	} else {
+		annotations["openshift.io/scc"] = "restricted"
 	}
 	return annotations
 }


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/36804
```
k describe po audit-policy-controller-59ff5646c5-5s5mx
Name:           audit-policy-controller-59ff5646c5-5s5mx
Namespace:      ibm-common-services
Priority:       0
Node:           worker1.audit-op.os.fyre.ibm.com/10.26.8.130
Start Time:     Mon, 13 Apr 2020 10:28:42 -0500
Labels:         app=audit-policy-controller
                app.kubernetes.io/component=common-audit-logging
                app.kubernetes.io/instance=common-audit-logging
                app.kubernetes.io/managed-by=operator
                app.kubernetes.io/name=audit-policy-controller
                auditlogging_cr=example-auditlogging
                component=common-audit-logging
                pod-template-hash=59ff5646c5
                release=common-audit-logging
Annotations:    k8s.v1.cni.cncf.io/networks-status:
                  [{
                      "name": "openshift-sdn",
                      "interface": "eth0",
                      "ips": [
                          "10.254.5.237"
                      ],
                      "dns": {},
                      "default-route": [
                          "10.254.4.1"
                      ]
                  }]
                openshift.io/scc: restricted
                productID: 068a62892a1e4db39641342e592daa25
                productMetric: FREE
                productName: IBM Cloud Platform Common Services
                productVersion: 3.3.0
```

```
audit-logging git:(ubi8) ✗ k exec -it audit-policy-controller-59ff5646c5-5s5mx bash
bash-4.2$ whoami
1000540000
```

```
Available policies in namespaces:
namespace = default; policy = iam-audit-policy-example
namespace = ibm-common-services; policy = iam-audit-policy-example
Violated count in namespace:  default 0
Violated service list:  []
Violated count in namespace:  ibm-common-services 1
Violated service list:  [platform-identity-manager]
Updating configmap, setting to true platform-auth-idp
Non compliant, updating event to warning
In printMap for AuditPolicy:  2
Available policies in namespaces:
namespace = default; policy = iam-audit-policy-example
namespace = ibm-common-services; policy = iam-audit-policy-example
Violated count in namespace:  default 0
Violated service list:  []
Violated count in namespace:  ibm-common-services 0
Violated service list:  []
```
```
Status:
  Audit Details:
    Iam - Audit - Policy - Example:
      Default:
        0 violations, services detected with audit disabled in namespace `default`
      Ibm - Common - Services:
        0 violations, services detected with audit disabled in namespace `ibm-common-services`
  Compliant:  Compliant
Events:
  Type     Reason                                                Age                 From                    Message
  ----     ------                                                ----                ----                    -------
  Warning  policy: ibm-common-services/iam-audit-policy-example  36s (x3 over 117s)  auditpolicy-controller  NonCompliant; [1 violations, services detected with audit disabled in namespace `ibm-common-services`  platform-identity-manager]; [0 violations, services detected with audit disabled in namespace `default` ]
  Warning  policy: ibm-common-services/iam-audit-policy-example  25s (x7 over 107s)  auditpolicy-controller  NonCompliant; [0 violations, services detected with audit disabled in namespace `default` ]; [1 violations, services detected with audit disabled in namespace `ibm-common-services`  platform-identity-manager]
  Normal   policy: ibm-common-services/iam-audit-policy-example  5s (x2 over 15s)    auditpolicy-controller  Compliant; [0 violations, services detected with audit disabled in namespace `default` ]; [0 violations, services detected with audit disabled in namespace `ibm-common-services` ]
```

