### PR TITLE
fix matches bug

### DIFF
--- a/pkg/resources/containers.go
+++ b/pkg/resources/containers.go
@@ -162,7 +162,7 @@ var sourceConfigData4 = `
 
 var splunkConfigData = `
 splunkHEC.conf: |-
-     <match icp-audit.**>
+     <match icp-audit icp-audit.**>
         @type splunk_hec
         hec_host SPLUNK_SERVER_HOSTNAME
         hec_port SPLUNK_PORT
@@ -173,7 +173,7 @@ splunkHEC.conf: |-
 
 var qRadarConfigData = `
 remoteSyslog.conf: |-
-    <match icp-audit.**>
+    <match icp-audit icp-audit.**>
         @type copy
         <store>
           @type remote_syslog


### PR DESCRIPTION
There was a bug where the output conf would only match to one `icp-audit.**` being the systemd logs with `icp-audit`. In order to match both, the config needed to be changed to `match icp-audit icp-audit.**` 

https://github.ibm.com/PrivateCloud-analytics/audit-logging/blob/3.0.0.0/fluent_source.conf#L45