### PR TITLE
fix index out of bounds for empty match

### DIFF
--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -640,12 +640,19 @@ func EqualDaemonSets(expected *appsv1.DaemonSet, found *appsv1.DaemonSet) bool {
 }
 
 func EqualSourceConfig(expected *corev1.ConfigMap, found *corev1.ConfigMap) (bool, []string) {
+	var ports []string
+	var foundPort string
 	re := regexp.MustCompile("port [0-9]+")
-	var match = re.FindStringSubmatch(found.Data[SourceConfigKey])[0]
-	foundPort := strings.Split(match, " ")[1]
-	match = re.FindStringSubmatch(expected.Data[SourceConfigKey])[0]
-	expectedPort := strings.Split(match, " ")[1]
-	return (foundPort != expectedPort), []string{foundPort, expectedPort}
+	var match = re.FindStringSubmatch(found.Data[SourceConfigKey])
+	if len(match) < 1 {
+		foundPort = ""
+	} else {
+		foundPort = strings.Split(match[0], " ")[1]
+	}
+	ports = append(ports, foundPort)
+	match = re.FindStringSubmatch(expected.Data[SourceConfigKey])
+	expectedPort := strings.Split(match[0], " ")[1]
+	return (foundPort != expectedPort), append(ports, expectedPort)
 }
 
 // GetPodNames returns the pod names of the array of pods passed in


### PR DESCRIPTION
```
E0422 18:44:07.577519       1 runtime.go:78] Observed a panic: runtime.boundsError{x:0, y:0, signed:true, code:0x0} (runtime error: index out of range [0] with length 0)
goroutine 1400 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1561de0, 0xc000656180)
	/home/prow/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191004115801-a2eda9f80ab8/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/home/prow/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191004115801-a2eda9f80ab8/pkg/util/runtime/runtime.go:48 +0x82
panic(0x1561de0, 0xc000656180)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/ibm/ibm-auditlogging-operator/pkg/resources.EqualSourceConfig(0xc00016c780, 0xc00016ca00, 0x26, 0x164d401, 0x13, 0x16643d5)
	/home/prow/go/src/github.com/IBM/ibm-auditlogging-operator/pkg/resources/utils.go:644 +0x2fa
github.com/ibm/ibm-auditlogging-operator/pkg/controller/auditlogging.(*ReconcileAuditLogging).createOrUpdateConfig(0xc0001e7480, 0xc00068ab40, 0x16643d5, 0x26, 0x182fc00, 0x0, 0x0, 0x0)
	/home/prow/go/src/github.com/IBM/ibm-auditlogging-operator/pkg/controller/auditlogging/auditlogging.go:444 +0x295
github.com/ibm/ibm-auditlogging-operator/pkg/controller/auditlogging.(*ReconcileAuditLogging).createOrUpdateAuditConfigMaps(0xc0001e7480, 0xc00068ab40, 0xc000044050, 0x0, 0x0, 0xc0008d96c0)
	/home/prow/go/src/github.com/IBM/ibm-auditlogging-operator/pkg/controller/auditlogging/auditlogging.go:399 +0xb5
github.com/ibm/ibm-auditlogging-operator/pkg/controller/auditlogging.(*ReconcileAuditLogging).Reconcile(0xc0001e7480, 0x0, 0x0, 0xc0008d96c0, 0x14, 0xc000a33cd8, 0xc0006a9050, 0xc0006023f8, 0x1836bc0)
	/home/prow/go/src/github.com/IBM/ibm-auditlogging-operator/pkg/controller/auditlogging/auditlogging_controller.go:155 +0x2f2
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000808cc0, 0x14da7c0, 0xc00080eca0, 0x0)
	/home/prow/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:256 +0x162
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000808cc0, 0x1166400)
	/home/prow/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:232 +0xcb
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc000808cc0)
	/home/prow/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:211 +0x2b
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000b51250)
	/home/prow/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191004115801-a2eda9f80ab8/pkg/util/wait/wait.go:152 +0x5e
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000b51250, 0x3b9aca00, 0x0, 0x1, 0xc0001ffb00)
	/home/prow/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191004115801-a2eda9f80ab8/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc000b51250, 0x3b9aca00, 0xc0001ffb00)
	/home/prow/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191004115801-a2eda9f80ab8/pkg/util/wait/wait.go:88 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
	/home/prow/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:193 +0x328
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0
```