### PR TITLE
codecov only unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,8 @@ test-e2e: ## Run integration e2e tests
 # coverage section
 ############################################################
 
-coverage:
-	@common/scripts/codecov.sh ${BUILD_LOCALLY}
+coverage: ## Run code coverage test
+	@common/scripts/codecov.sh ${BUILD_LOCALLY} "pkg/controller"
 
 ############################################################
 # install operator sdk section


### PR DESCRIPTION
prow build fails on codecov step since it tries to run e2e tests without a kubeconfig
```
FAIL	github.com/ibm/ibm-auditlogging-operator/test/e2e	0.113s
FAIL
time="2020-04-27T13:56:24Z" level=fatal msg="Failed to create framework: failed to build the kubeconfig: invalid configuration: no configuration has been provided"
FAIL	github.com/ibm/ibm-auditlogging-operator/test/e2e	0.052s
FAIL
time="2020-04-27T13:56:29Z" level=fatal msg="Failed to create framework: failed to build the kubeconfig: invalid configuration: no configuration has been provided"
FAIL	github.com/ibm/ibm-auditlogging-operator/test/e2e	0.138s
FAIL
time="2020-04-27T13:56:34Z" level=fatal msg="Failed to create framework: failed to build the kubeconfig: invalid configuration: no configuration has been provided"
FAIL	github.com/ibm/ibm-auditlogging-operator/test/e2e	0.103s
FAIL