### PR TITLE
fix defaults to match doc

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_auditlogging_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_auditlogging_cr.yaml
@@ -8,10 +8,10 @@ metadata:
     app.kubernetes.io/name: "common-audit-logging"
 spec:
   fluentd:
-    enabled: true
+    enabled: false
     imageRegistry: quay.io/opencloudio/
     pullPolicy: IfNotPresent
-    journalPath: /var/log/journal
+    journalPath: /run/log/journal
   policyController:
     imageRegistry: quay.io/opencloudio/
     pullPolicy: IfNotPresent

--- a/deploy/crds/operator.ibm.com_v1alpha1_auditlogging_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_auditlogging_cr.yaml
@@ -12,7 +12,9 @@ spec:
     imageRegistry: quay.io/opencloudio/
     pullPolicy: IfNotPresent
     journalPath: /run/log/journal
+    clusterIssuer: cs-ca-clusterissuer
   policyController:
     imageRegistry: quay.io/opencloudio/
     pullPolicy: IfNotPresent
     verbosity: "0"
+    frequency: "10"

--- a/deploy/olm-catalog/ibm-auditlogging-operator/3.6.0/ibm-auditlogging-operator.v3.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-auditlogging-operator/3.6.0/ibm-auditlogging-operator.v3.6.0.clusterserviceversion.yaml
@@ -12,9 +12,9 @@ metadata:
           },
           "spec": {
             "fluentd": {
-              "enabled": true,
+              "enabled": false,
               "imageRegistry": "quay.io/opencloudio/",
-              "journalPath": "/var/log/journal",
+              "journalPath": "/run/log/journal",
               "pullPolicy": "IfNotPresent"
             },
             "policyController": {

--- a/deploy/olm-catalog/ibm-auditlogging-operator/3.6.0/ibm-auditlogging-operator.v3.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-auditlogging-operator/3.6.0/ibm-auditlogging-operator.v3.6.0.clusterserviceversion.yaml
@@ -15,12 +15,14 @@ metadata:
               "enabled": false,
               "imageRegistry": "quay.io/opencloudio/",
               "journalPath": "/run/log/journal",
-              "pullPolicy": "IfNotPresent"
+              "pullPolicy": "IfNotPresent",
+              "clusterIssuer": "cs-ca-clusterissuer"
             },
             "policyController": {
               "imageRegistry": "quay.io/opencloudio/",
               "pullPolicy": "IfNotPresent",
-              "verbosity": "0"
+              "verbosity": "0",
+              "frequency" "10"
             }
           }
         },

--- a/pkg/controller/auditlogging/auditlogging.go
+++ b/pkg/controller/auditlogging/auditlogging.go
@@ -600,17 +600,15 @@ func (r *ReconcileAuditLogging) reconcileAuditCertificate(instance *operatorv1al
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: expectedCert.Name, Namespace: expectedCert.ObjectMeta.Namespace}, foundCert)
 	if err != nil && errors.IsNotFound(err) {
 		// Set Audit Logging instance as the owner and controller of the Certificate
-		err := controllerutil.SetControllerReference(instance, expectedCert, r.scheme)
-		if err != nil && errors.IsAlreadyExists(err) {
-			// Already exists from previous reconcile, requeue.
-			return reconcile.Result{Requeue: true}, nil
-		} else if err != nil {
-			reqLogger.Error(err, "Failed to set owner for Certificate")
+		if err := controllerutil.SetControllerReference(instance, expectedCert, r.scheme); err != nil {
 			return reconcile.Result{}, err
 		}
 		reqLogger.Info("Creating a new Fluentd Certificate", "Certificate.Namespace", expectedCert.Namespace, "Certificate.Name", expectedCert.Name)
 		err = r.client.Create(context.TODO(), expectedCert)
-		if err != nil {
+		if err != nil && errors.IsAlreadyExists(err) {
+			// Already exists from previous reconcile, requeue.
+			return reconcile.Result{Requeue: true}, nil
+		} else if err != nil {
 			reqLogger.Error(err, "Failed to create new Fluentd Certificate", "Certificate.Namespace", expectedCert.Namespace,
 				"Certificate.Name", expectedCert.Name)
 			return reconcile.Result{}, err


### PR DESCRIPTION
For this release (3.6.0) the default is
```
apiVersion: operator.ibm.com/v1alpha1
kind: AuditLogging
metadata:
  name: example-auditlogging
spec:
  fluentd:
    enabled: false
    imageRegistry: quay.io/opencloudio/
    pullPolicy: IfNotPresent
    journalPath: /run/log/journal
  policyController:
    imageRegistry: quay.io/opencloudio/
    pullPolicy: IfNotPresent
    verbosity: "0"
```
These defaults are the same if a customer does not define these fields