### PR TITLE
fix update status

### DIFF
--- a/pkg/controller/auditlogging/auditlogging.go
+++ b/pkg/controller/auditlogging/auditlogging.go
@@ -19,6 +19,7 @@ package auditlogging
 import (
 	"context"
 	"reflect"
+	"sort"
 
 	operatorv1alpha1 "github.com/ibm/ibm-auditlogging-operator/pkg/apis/operator/v1alpha1"
 	res "github.com/ibm/ibm-auditlogging-operator/pkg/resources"
@@ -65,6 +66,8 @@ func (r *ReconcileAuditLogging) updateStatus(instance *operatorv1alpha1.AuditLog
 	for _, pod := range podList.Items {
 		podNames = append(podNames, pod.Name)
 	}
+
+	sort.Strings(podNames)
 
 	// Update status.Nodes if needed
 	if !reflect.DeepEqual(podNames, instance.Status.Nodes) {

--- a/pkg/controller/auditlogging/auditlogging_controller_test.go
+++ b/pkg/controller/auditlogging/auditlogging_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"sort"
 	"testing"
 
 	operatorv1alpha1 "github.com/ibm/ibm-auditlogging-operator/pkg/apis/operator/v1alpha1"
@@ -263,6 +264,7 @@ func checkFluentdConfig(t *testing.T, r ReconcileAuditLogging, req reconcile.Req
 	// Get the updated AuditLogging object.
 	al := getAuditLogging(t, r, req)
 	nodes := al.Status.Nodes
+	sort.Strings(podNames)
 	if !reflect.DeepEqual(podNames, nodes) {
 		t.Errorf("pod names %v did not match expected %v", nodes, podNames)
 	}


### PR DESCRIPTION
Status was updating every reconcile loop because DeepEqual would return false if two slices with the same elements had different orders

Ex:
```{"level":"info","ts":1589402004.227247,"logger":"controller_auditlogging","msg":"Reconciling AuditLogging","Request.Namespace":"","Request.Name":"example-auditlogging"}
{"level":"info","ts":1589402004.2284575,"logger":"controller_auditlogging","msg":"Updating Audit Logging status","Namespace":"ibm-common-services","Name":"example-auditlogging","Name":"example-auditlogging"}
{"level":"info","ts":1589402004.2466183,"logger":"controller_auditlogging","msg":"Reconciliation successful!","Request.Namespace":"","Request.Name":"example-auditlogging","Name":"example-auditlogging"}
{"level":"info","ts":1589402009.2469664,"logger":"controller_auditlogging","msg":"Reconciling AuditLogging","Request.Namespace":"","Request.Name":"example-auditlogging"}
{"level":"info","ts":1589402009.2493558,"logger":"controller_auditlogging","msg":"Updating Audit Logging status","Namespace":"ibm-common-services","Name":"example-auditlogging","Name":"example-auditlogging"}
{"level":"info","ts":1589402009.2694654,"logger":"controller_auditlogging","msg":"Reconciliation successful!","Request.Namespace":"","Request.Name":"example-auditlogging","Name":"example-auditlogging"}
{"level":"info","ts":1589402014.2698839,"logger":"controller_auditlogging","msg":"Reconciling AuditLogging","Request.Namespace":"","Request.Name":"example-auditlogging"}
{"level":"info","ts":1589402014.2715676,"logger":"controller_auditlogging","msg":"Updating Audit Logging status","Namespace":"ibm-common-services","Name":"example-auditlogging","Name":"example-auditlogging"}
{"level":"info","ts":1589402014.297365,"logger":"controller_auditlogging","msg":"Reconciliation successful!","Request.Namespace":"","Request.Name":"example-auditlogging","Name":"example-auditlogging"}
{"level":"info","ts":1589402019.2983158,"logger":"controller_auditlogging","msg":"Reconciling AuditLogging","Request.Namespace":"","Request.Name":"example-auditlogging"}
{"level":"info","ts":1589402019.299557,"logger":"controller_auditlogging","msg":"Updating Audit Logging status","Namespace":"ibm-common-services","Name":"example-auditlogging","Name":"example-auditlogging"}
{"level":"info","ts":1589402019.3148406,"logger":"controller_auditlogging","msg":"Reconciliation successful!","Request.Namespace":"","Request.Name":"example-auditlogging","Name":"example-auditlogging"}
{"level":"info","ts":1589402024.3150897,"logger":"controller_auditlogging","msg":"Reconciling AuditLogging","Request.Namespace":"","Request.Name":"example-auditlogging"}
{"level":"info","ts":1589402024.3172126,"logger":"controller_auditlogging","msg":"Reconciliation successful!","Request.Namespace":"","Request.Name":"example-auditlogging","Name":"example-auditlogging"}
{"level":"info","ts":1589402032.563511,"logger":"controller_auditlogging","msg":"Reconciling AuditLogging","Request.Namespace":"","Request.Name":"example-auditlogging"}
{"level":"info","ts":1589402032.565134,"logger":"controller_auditlogging","msg":"Reconciliation successful!","Request.Namespace":"","Request.Name":"example-auditlogging","Name":"example-auditlogging"}
{"level":"info","ts":1589402037.5850797,"logger":"controller_auditlogging","msg":"Reconciling AuditLogging","Request.Namespace":"","Request.Name":"example-auditlogging"}
{"level":"info","ts":1589402037.5863216,"logger":"controller_auditlogging","msg":"Updating Audit Logging status","Namespace":"ibm-common-services","Name":"example-auditlogging","Name":"example-auditlogging"}
{"level":"info","ts":1589402037.5987806,"logger":"controller_auditlogging","msg":"Reconciliation successful!","Request.Namespace":"","Request.Name":"example-auditlogging","Name":"example-auditlogging"}
{"level":"info","ts":1589402042.5991538,"logger":"controller_auditlogging","msg":"Reconciling AuditLogging","Request.Namespace":"","Request.Name":"example-auditlogging"}
{"level":"info","ts":1589402042.6012352,"logger":"controller_auditlogging","msg":"Updating Audit Logging status","Namespace":"ibm-common-services","Name":"example-auditlogging","Name":"example-auditlogging"}
{"level":"info","ts":1589402042.619475,"logger":"controller_auditlogging","msg":"Reconciliation successful!","Request.Namespace":"","Request.Name":"example-auditlogging","Name":"example-auditlogging"}
{"level":"info","ts":1589402047.619919,"logger":"controller_auditlogging","msg":"Reconciling AuditLogging","Request.Namespace":"","Request.Name":"example-auditlogging"}
{"level":"info","ts":1589402047.6216562,"logger":"controller_auditlogging","msg":"Updating Audit Logging status","Namespace":"ibm-common-services","Name":"example-auditlogging","Name":"example-auditlogging"}
```