### PR TITLE
update csv with operands sha

### DIFF
--- a/deploy/olm-catalog/ibm-auditlogging-operator/3.6.0/ibm-auditlogging-operator.v3.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-auditlogging-operator/3.6.0/ibm-auditlogging-operator.v3.6.0.clusterserviceversion.yaml
@@ -364,9 +364,9 @@ spec:
                 - name: OPERATOR_NAME
                   value: ibm-auditlogging-operator
                 - name: POLICY_CTRL_TAG_OR_SHA
-                  value: 3.5.0
+                  value: "sha256:6b681f6dee47b8c4cb3a54284d3112003fd6a88a4cdfff06eef7289f3fd2d409"
                 - name: FLUENTD_TAG_OR_SHA
-                  value: v1.6.2-ruby25
+                  value: "sha256:d9bbc6c3f8dc0299abd0927285c40b8f61878aafaae3928340991ce0436ff854"
                 image: quay.io/opencloudio/ibm-auditlogging-operator:latest
                 imagePullPolicy: Always
                 name: ibm-auditlogging-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -55,9 +55,9 @@ spec:
               value: "ibm-auditlogging-operator"
             # DO NOT DELETE. Add image SHAs here. See get_image_sha.sh
             - name: POLICY_CTRL_TAG_OR_SHA
-              value: 3.5.0
+              value: "sha256:6b681f6dee47b8c4cb3a54284d3112003fd6a88a4cdfff06eef7289f3fd2d409"
             - name: FLUENTD_TAG_OR_SHA
-              value: v1.6.2-ruby25
+              value: "sha256:d9bbc6c3f8dc0299abd0927285c40b8f61878aafaae3928340991ce0436ff854"
           resources:
             limits:
               cpu: 100m

--- a/test/e2e/auditlogging_test.go
+++ b/test/e2e/auditlogging_test.go
@@ -18,7 +18,6 @@ package e2e
 import (
 	"testing"
 
-	"github.com/operator-framework/operator-sdk/pkg/test"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 
@@ -46,9 +45,9 @@ func TestAuditLoggingOperator(t *testing.T) {
 	t.Run("TestAuditLogging", testgroups.TestAuditLogging)
 }
 
-func deployOperator(t *testing.T, ctx *test.TestCtx) error {
+func deployOperator(t *testing.T, ctx *framework.TestCtx) error {
 	err := ctx.InitializeClusterResources(
-		&test.CleanupOptions{
+		&framework.CleanupOptions{
 			TestContext:   ctx,
 			Timeout:       config.CleanupTimeout,
 			RetryInterval: config.CleanupRetry,
@@ -67,7 +66,7 @@ func deployOperator(t *testing.T, ctx *test.TestCtx) error {
 
 	return e2eutil.WaitForOperatorDeployment(
 		t,
-		test.Global.KubeClient,
+		framework.Global.KubeClient,
 		namespace,
 		config.TestOperatorName,
 		1,


### PR DESCRIPTION
- ran `make get-all-image-sha` and added to csv

- linter threw this error `test/e2e/auditlogging_test.go:21:2: ST1019: package "github.com/operator-framework/operator-sdk/pkg/test" is being imported more than once (stylecheck)` so fix added to this pr as well