### PR TITLE
fix(controller): don't allow auditlogging to run with commonaudit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
+	k8s.io/kubernetes v1.16.2
 	sigs.k8s.io/controller-runtime v0.5.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1170,6 +1170,7 @@ k8s.io/kube-state-metrics v1.7.2/go.mod h1:U2Y6DRi07sS85rmVPmBFlmv+2peBcL8IWGjM+
 k8s.io/kubectl v0.0.0-20191016120415-2ed914427d51/go.mod h1:gL826ZTIfD4vXTGlmzgTbliCAT9NGiqpCqK2aNYv5MQ=
 k8s.io/kubelet v0.0.0-20191016114556-7841ed97f1b2/go.mod h1:SBvrtLbuePbJygVXGGCMtWKH07+qrN2dE1iMnteSG8E=
 k8s.io/kubernetes v1.16.0/go.mod h1:nlP2zevWKRGKuaaVbKIwozU0Rjg9leVDXkL4YTtjmVs=
+k8s.io/kubernetes v1.16.2 h1:k0f/OVp6Yfv+UMTm6VYKhqjRgcvHh4QhN9coanjrito=
 k8s.io/kubernetes v1.16.2/go.mod h1:SmhGgKfQ30imqjFVj8AI+iW+zSyFsswNErKYeTfgoH0=
 k8s.io/legacy-cloud-providers v0.0.0-20191016115753-cf0698c3a16b/go.mod h1:tKW3pKqdRW8pMveUTpF5pJuCjQxg6a25iLo+Z9BXVH0=
 k8s.io/metrics v0.0.0-20191016113814-3b1a734dba6e/go.mod h1:ve7/vMWeY5lEBkZf6Bt5TTbGS3b8wAxwGbdXAsufjRs=

--- a/pkg/controller/auditlogging/auditlogging_controller.go
+++ b/pkg/controller/auditlogging/auditlogging_controller.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"time"
 
+	operatorv1 "github.com/ibm/ibm-auditlogging-operator/pkg/apis/operator/v1"
 	operatorv1alpha1 "github.com/ibm/ibm-auditlogging-operator/pkg/apis/operator/v1alpha1"
 	res "github.com/ibm/ibm-auditlogging-operator/pkg/resources"
 
@@ -31,6 +32,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -50,7 +52,11 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileAuditLogging{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+	return &ReconcileAuditLogging{
+		client:   mgr.GetClient(),
+		scheme:   mgr.GetScheme(),
+		recorder: mgr.GetEventRecorderFor("ibm-auditlogging-operator"),
+	}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -100,8 +106,9 @@ var _ reconcile.Reconciler = &ReconcileAuditLogging{}
 type ReconcileAuditLogging struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client client.Client
-	scheme *runtime.Scheme
+	client   client.Client
+	scheme   *runtime.Scheme
+	recorder record.EventRecorder
 }
 
 // Reconcile reads that state of the cluster for a AuditLogging object and makes changes based on the state read
@@ -138,6 +145,27 @@ func (r *ReconcileAuditLogging) Reconcile(request reconcile.Request) (reconcile.
 			return reconcile.Result{}, err
 		}
 	}
+
+	auditLoggingList := &operatorv1alpha1.AuditLoggingList{}
+	if err := r.client.List(context.TODO(), auditLoggingList); err == nil && len(auditLoggingList.Items) > 1 {
+		msg := "Only one instance of AuditLogging per cluster. Delete other instances to proceed."
+		reqLogger.Info(msg)
+		r.updateEvent(instance, msg, corev1.EventTypeWarning, "Not Allowed")
+		// Return and don't requeue
+		return reconcile.Result{}, nil
+	}
+
+	commonAuditList := &operatorv1.CommonAuditList{}
+	if err := r.client.List(context.TODO(), commonAuditList, client.InNamespace(res.InstanceNamespace)); err == nil &&
+		len(commonAuditList.Items) > 0 {
+		msg := "CommonAudit cannot run alongside AuditLogging in the same namespace. Delete one or the other to proceed."
+		reqLogger.Info(msg)
+		r.updateEvent(instance, msg, corev1.EventTypeWarning, "Not Allowed")
+		// Return and don't requeue
+		return reconcile.Result{}, nil
+	}
+
+	r.updateEvent(instance, "Instance found", corev1.EventTypeNormal, "Initializing")
 
 	var recResult reconcile.Result
 	var recErr error
@@ -199,4 +227,8 @@ func (r *ReconcileAuditLogging) updateStatus(instance *operatorv1alpha1.AuditLog
 		}
 	}
 	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileAuditLogging) updateEvent(instance *operatorv1alpha1.AuditLogging, message, event, reason string) {
+	r.recorder.Event(instance, event, reason, message)
 }

--- a/pkg/controller/auditlogging/auditlogging_controller.go
+++ b/pkg/controller/auditlogging/auditlogging_controller.go
@@ -191,7 +191,7 @@ func (r *ReconcileAuditLogging) Reconcile(request reconcile.Request) (reconcile.
 	// Delete service accounts if they were leftover from a previous version.
 	// Policy controller deployment has been moved to operator pod in 3.7, remove redundant rbac
 	r.removeOldRBAC(instance)
-
+	r.updateEvent(instance, "Deployed "+res.AuditLoggingComponentName+" successfully", corev1.EventTypeNormal, "Deployed")
 	reqLogger.Info("Reconciliation successful!", "Name", instance.Name)
 	// since we updated the status in the Audit Logging CR, sleep 5 seconds to allow the CR to be refreshed.
 	time.Sleep(5 * time.Second)

--- a/pkg/controller/auditlogging/auditlogging_controller_test.go
+++ b/pkg/controller/auditlogging/auditlogging_controller_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/kubernetes/pkg/controller/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -331,8 +332,9 @@ func getReconciler(cr *operatorv1alpha1.AuditLogging) ReconcileAuditLogging {
 
 	// Return a ReconcileOperandRequest object with the scheme and fake client.
 	return ReconcileAuditLogging{
-		scheme: s,
-		client: client,
+		scheme:   s,
+		client:   client,
+		recorder: testutil.NewFakeRecorder(),
 	}
 }
 

--- a/pkg/controller/commonaudit/commonaudit_controller_test.go
+++ b/pkg/controller/commonaudit/commonaudit_controller_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/kubernetes/pkg/controller/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -354,8 +355,9 @@ func getReconciler(cr *operatorv1.CommonAudit) ReconcileCommonAudit {
 
 	// Return a ReconcileOperandRequest object with the scheme and fake client.
 	return ReconcileCommonAudit{
-		scheme: s,
-		client: client,
+		scheme:   s,
+		client:   client,
+		recorder: testutil.NewFakeRecorder(),
 	}
 }
 


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/39773

`oc delete auditlogging example-auditlogging`
and then
created commonaudit in ibm-common-services
and then
`kubectl apply -f deploy/crds/operator.ibm.com_v1alpha1_auditlogging_cr.yaml -n ibm-common-services`
and now i have
```
lauriet@Lauries-MacBook-Pro-1 audit-logging-bats % oc get pods | grep audit
audit-log-test-57cccff668-rbnbm                          1/1     Running     0          20m
audit-logging-fluentd-66cb54b6fd-pdvhq                   1/1     Running     0          23m
audit-logging-fluentd-ds-2vmrf                           1/1     Running     0          116s
audit-logging-fluentd-ds-qzd8q                           1/1     Running     0          116s
audit-logging-fluentd-ds-szwsn                           1/1     Running     0          116s
ibm-auditlogging-operator-7b848ccc7f-68kqc               2/2     Running     0          10h
```

**Prereq**s:
- `ibm-common-services` namespace
- `ibm-cert-manager-operator` installed on your cluster
- Secret for artifactory scratch repo named `docker-scratch`: `oc create secret -n ibm-common-services docker-registry docker-scratch  --docker-server=hyc-cloud-private-scratch-docker-local.artifactory.swg-devops.com --docker-username=<REPLACE_ME>  --docker-password=<<REPLACE_ME> --docker-email=<REPLACE_ME>`

**Testing**: 
- Replace operator container image in 3.7.0 csv with `hyc-cloud-private-scratch-docker-local.artifactory.swg-devops.com/audit-operator:test`
- Update AuditLogging CR and CommonAudit CR to use `fluentd.imageRegistry: hyc-cloud-private-scratch-docker-local.artifactory.swg-devops.com/ibmcom` 
- Configure rest of AuditLogging CR and CommonAudit CR 
- `make install`

Note: If fluentd cannot pull scratch images, add `docker-scratch` as an `ImagePullSecret` to the deploy/dameonset