### PR TITLE
fix(csv): use sha for operands

### DIFF
--- a/deploy/olm-catalog/ibm-auditlogging-operator/3.7.0/ibm-auditlogging-operator.v3.7.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-auditlogging-operator/3.7.0/ibm-auditlogging-operator.v3.7.0.clusterserviceversion.yaml
@@ -484,9 +484,9 @@ spec:
                 - name: OPERATOR_NAME
                   value: ibm-auditlogging-operator
                 - name: POLICY_CTRL_TAG_OR_SHA
-                  value: 3.5.1
+                  value: sha256:a41c7ce5574d3b84a083b748ff82a41f2736743aa7299be10e89030daa4e2ec4
                 - name: FLUENTD_TAG_OR_SHA
-                  value: v1.6.2-bedrock-0
+                  value: sha256:fa6a5922caed92ff38816a11a3098e17afd2300fb4688ac8ccf857365ffef9a5
                 image: quay.io/opencloudio/ibm-auditlogging-operator:latest
                 imagePullPolicy: Always
                 name: ibm-auditlogging-operator
@@ -507,7 +507,7 @@ spec:
                   runAsNonRoot: true
               - args:
                 - --v=0
-                image: hyc-cloud-private-integration-docker-local.artifactory.swg-devops.com/ibmcom/audit-policy-controller:3.5.1
+                image: quay.io/opencloudio/audit-policy-controller@sha256:a41c7ce5574d3b84a083b748ff82a41f2736743aa7299be10e89030daa4e2ec4
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   exec:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -56,9 +56,9 @@ spec:
               value: "ibm-auditlogging-operator"
             # DO NOT DELETE. Add image SHAs here. See get_image_sha.sh
             - name: POLICY_CTRL_TAG_OR_SHA
-              value: 3.5.1
+              value: sha256:a41c7ce5574d3b84a083b748ff82a41f2736743aa7299be10e89030daa4e2ec4
             - name: FLUENTD_TAG_OR_SHA
-              value: v1.6.2-bedrock-0
+              value: sha256:fa6a5922caed92ff38816a11a3098e17afd2300fb4688ac8ccf857365ffef9a5
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
Note: These operand images do not exist in quay. For testing and development you can manually change the operand repos to integration in the CR and CSV or follow this doc https://github.ibm.com/IBMPrivateCloud/ibm-common-service-catalog

https://github.ibm.com/IBMPrivateCloud/roadmap/issues/40147