### PR TITLE
fix(HA): add PodAntiAffinity

### DIFF
--- a/pkg/resources/deployments.go
+++ b/pkg/resources/deployments.go
@@ -100,8 +100,25 @@ func BuildDeploymentForFluentd(instance *operatorv1.CommonAudit) *appsv1.Deploym
 								},
 							},
 						},
+						PodAntiAffinity: &corev1.PodAntiAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app.kubernetes.io/name",
+												Operator: metav1.LabelSelectorOpIn,
+												Values: []string{
+													FluentdName,
+												},
+											},
+										},
+									},
+									TopologyKey: "kubernetes.io/hostname",
+								},
+							},
+						},
 					},
-					// NodeSelector:                  {},
 					Tolerations: commonTolerations,
 					Volumes:     volumes,
 					Containers: []corev1.Container{


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/40918
3 workers
scale replicas from 1 to 3:
```
➜  Desktop oc get po -o wide -w | grep audit
audit-logging-fluentd-5dcfd6975d-2cfhg             1/1     Running     0          40s     10.254.12.179   worker0.mykonos.os.fyre.ibm.com   <none>           <none>
audit-logging-fluentd-5dcfd6975d-ml48q             1/1     Running     0          40s     10.254.1.5      worker1.mykonos.os.fyre.ibm.com   <none>           <none>
audit-logging-fluentd-5dcfd6975d-r6d27             1/1     Running     0          39s     10.254.8.244    worker2.mykonos.os.fyre.ibm.com   <none>           <none>
```
scale replicas from 3 to 5
```
➜  Desktop oc get po -o wide | grep audit
audit-logging-fluentd-5dcfd6975d-2cfhg             1/1     Running     0          68s     10.254.12.179   worker0.mykonos.os.fyre.ibm.com   <none>           <none>
audit-logging-fluentd-5dcfd6975d-ml48q             1/1     Running     0          68s     10.254.1.5      worker1.mykonos.os.fyre.ibm.com   <none>           <none>
audit-logging-fluentd-5dcfd6975d-r6d27             1/1     Running     0          67s     10.254.8.244    worker2.mykonos.os.fyre.ibm.com   <none>           <none>
audit-logging-fluentd-5dcfd6975d-v6lw5             0/1     Pending     0          4s      <none>          <none>                            <none>           <none>
audit-logging-fluentd-5dcfd6975d-znf8k             0/1     Pending     0          4s      <none>          <none>                            <none>           <none>
```