### PR TITLE
fix(upgrade): labelselector is immutable after creation

### DIFF
--- a/controllers/util/utils.go
+++ b/controllers/util/utils.go
@@ -129,7 +129,7 @@ func LabelsForMetadata(name string) map[string]string {
 
 //IBMDEV
 func LabelsForSelector(name string, crName string) map[string]string {
-	return map[string]string{"app": name, "component": constant.AuditLoggingComponentName, constant.AuditLoggingCrType: crName, constant.AuditTypeLabel: name}
+	return map[string]string{"app": name, "component": constant.AuditLoggingComponentName, constant.AuditLoggingCrType: crName}
 }
 
 //IBMDEV

--- a/controllers/util/utils_test.go
+++ b/controllers/util/utils_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Utils", func() {
 		It("Should return labels with the operand name", func() {
 			crName := "test-cr"
 			expectedResult := map[string]string{"app": testString, "component": constant.AuditLoggingComponentName,
-				constant.AuditLoggingCrType: crName, constant.AuditTypeLabel: testString}
+				constant.AuditLoggingCrType: crName}
 			result := LabelsForSelector(testString, crName)
 			Expect(result).Should(Equal(expectedResult))
 		})
@@ -141,7 +141,7 @@ var _ = Describe("Utils", func() {
 			expectedResult := map[string]string{"app": testString, "app.kubernetes.io/name": testString,
 				"app.kubernetes.io/component": constant.AuditLoggingComponentName, "app.kubernetes.io/managed-by": "operator",
 				"app.kubernetes.io/instance": constant.AuditLoggingReleaseName, "release": constant.AuditLoggingReleaseName,
-				"component": constant.AuditLoggingComponentName, constant.AuditLoggingCrType: crName, constant.AuditTypeLabel: testString}
+				constant.AuditTypeLabel: testString, "component": constant.AuditLoggingComponentName, constant.AuditLoggingCrType: crName}
 			result := LabelsForPodMetadata(testString, crName)
 			Expect(result).Should(Equal(expectedResult))
 		})


### PR DESCRIPTION
```
2020-11-05T21:23:02.885Z	INFO	controller_auditlogging	Labels not equal	{"func": "EqualLabels", "Found": {"app":"fluentd","app.kubernetes.io/component":"common-audit-logging","app.kubernetes.io/instance":"common-audit-logging","app.kubernetes.io/managed-by":"operator","app.kubernetes.io/name":"fluentd","release":"common-audit-logging"}, "Expected": {"app":"fluentd","app.kubernetes.io/component":"common-audit-logging","app.kubernetes.io/instance":"common-audit-logging","app.kubernetes.io/managed-by":"operator","app.kubernetes.io/name":"fluentd","operator.ibm.com/managedBy-audit":"fluentd","release":"common-audit-logging"}}
2020-11-05T21:23:02.904Z	ERROR	controllers.AuditLogging	Failed to update Daemonset	{"Namespace": "ibm-common-services", "Name": "audit-logging-fluentd-ds", "error": "DaemonSet.apps \"audit-logging-fluentd-ds\" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{\"app\":\"fluentd\", \"auditlogging_cr\":\"example-auditlogging\", \"component\":\"common-audit-logging\", \"operator.ibm.com/managedBy-audit\":\"fluentd\"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable"}
github.com/go-logr/zapr.(*zapLogger).Error
	/go/pkg/mod/github.com/go-logr/zapr@v0.2.0/zapr.go:132
github.com/IBM/ibm-auditlogging-operator/controllers.(*AuditLoggingReconciler).reconcileFluentdDaemonSet
	/workspace/controllers/reconcile_auditlogging.go:263
github.com/IBM/ibm-auditlogging-operator/controllers.(*AuditLoggingReconciler).Reconcile
	/workspace/controllers/auditlogging_controller.go:125
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:235
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:209
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:188
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
	/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:155
k8s.io/apimachinery/pkg/util/wait.BackoffUntil
	/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:156
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:133
k8s.io/apimachinery/pkg/util/wait.Until
	/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:90