### PR TITLE
fix(cicd): use arch specific base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 FROM golang:1.14.7 as builder
-ARG GOARCH
+ARG GOARCH=amd64
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -37,7 +37,7 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o manager main.go
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # FROM gcr.io/distroless/static:nonroot
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-230
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:4a02f98dd98f11f0ab2849a57dcf4d9e33e24568e9e4ce81b549b60191b6c7d7
 
 ARG VCS_REF
 ARG VCS_URL

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -22,7 +22,7 @@ RUN chmod +x /qemu-ppc64le-static
 
 # Build the manager binary
 FROM golang:1.14.7 as builder
-ARG GOARCH
+ARG GOARCH=ppc64le
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -44,7 +44,7 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o manager main.go
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # FROM gcr.io/distroless/static:nonroot
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-230
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:f5b185532ece6cc482c8424280e2cdccb1b95b735e464ea7aef29dd13c768937
 
 ARG VCS_REF
 ARG VCS_URL

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -22,7 +22,7 @@ RUN chmod +x /qemu-s390x-static
 
 # Build the manager binary
 FROM golang:1.14.7 as builder
-ARG GOARCH
+ARG GOARCH=s390x
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -45,7 +45,7 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o manager main.go
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # FROM gcr.io/distroless/static:nonroot
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-230
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:768552c16ef80d4e7cf28e29266322dc5d6b68a431a41afd74757a3f0eff03e2
 
 ARG VCS_REF
 ARG VCS_URL

--- a/Makefile
+++ b/Makefile
@@ -248,20 +248,17 @@ build-bundle-image: ## Build operator bundle image
 
 build-image-amd64: ## Build amd64 operator image
 	@docker build -t $(IMAGE_REPO)/$(IMAGE_NAME)-amd64:$(VERSION) \
-	--build-arg VCS_REF=$(VCS_REF) --build-arg VCS_URL=$(VCS_URL) \
-	--build-arg GOARCH=amd64 -f Dockerfile .
+	--build-arg VCS_REF=$(VCS_REF) --build-arg VCS_URL=$(VCS_URL) -f Dockerfile .
 
 build-image-ppc64le: ## Build ppcle64 operator image
 	@docker run --rm --privileged multiarch/qemu-user-static:register --reset
 	@docker build -t $(IMAGE_REPO)/$(IMAGE_NAME)-ppc64le:$(VERSION) \
-	--build-arg VCS_REF=$(VCS_REF) --build-arg VCS_URL=$(VCS_URL) \
-	--build-arg GOARCH=ppc64le -f Dockerfile.ppc64le .
+	--build-arg VCS_REF=$(VCS_REF) --build-arg VCS_URL=$(VCS_URL) -f Dockerfile.ppc64le .
 
 build-image-s390x: ## Build s390x operator image
 	@docker run --rm --privileged multiarch/qemu-user-static:register --reset
 	@docker build -t $(IMAGE_REPO)/$(IMAGE_NAME)-s390x:$(VERSION) \
-	--build-arg VCS_REF=$(VCS_REF) --build-arg VCS_URL=$(VCS_URL) \
-	--build-arg GOARCH=s390x -f Dockerfile.s390x .
+	--build-arg VCS_REF=$(VCS_REF) --build-arg VCS_URL=$(VCS_URL) -f Dockerfile.s390x .
 
 push-image-amd64: $(CONFIG_DOCKER_TARGET) build-image-amd64 ## Push amd64 operator image
 	@docker push $(IMAGE_REPO)/$(IMAGE_NAME)-amd64:$(VERSION)


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/43584
```
➜  ibm-auditlogging-operator git:(hbradfield-43584) ✗ make build-image-ppc64le
Setting /usr/bin/qemu-alpha-static as binfmt interpreter for alpha
Setting /usr/bin/qemu-arm-static as binfmt interpreter for arm
Setting /usr/bin/qemu-armeb-static as binfmt interpreter for armeb
Setting /usr/bin/qemu-sparc-static as binfmt interpreter for sparc
Setting /usr/bin/qemu-sparc32plus-static as binfmt interpreter for sparc32plus
Setting /usr/bin/qemu-sparc64-static as binfmt interpreter for sparc64
Setting /usr/bin/qemu-ppc-static as binfmt interpreter for ppc
Setting /usr/bin/qemu-ppc64-static as binfmt interpreter for ppc64
Setting /usr/bin/qemu-ppc64le-static as binfmt interpreter for ppc64le
Setting /usr/bin/qemu-m68k-static as binfmt interpreter for m68k
Setting /usr/bin/qemu-mips-static as binfmt interpreter for mips
Setting /usr/bin/qemu-mipsel-static as binfmt interpreter for mipsel
Setting /usr/bin/qemu-mipsn32-static as binfmt interpreter for mipsn32
Setting /usr/bin/qemu-mipsn32el-static as binfmt interpreter for mipsn32el
Setting /usr/bin/qemu-mips64-static as binfmt interpreter for mips64
Setting /usr/bin/qemu-mips64el-static as binfmt interpreter for mips64el
Setting /usr/bin/qemu-sh4-static as binfmt interpreter for sh4
Setting /usr/bin/qemu-sh4eb-static as binfmt interpreter for sh4eb
Setting /usr/bin/qemu-s390x-static as binfmt interpreter for s390x
Setting /usr/bin/qemu-aarch64-static as binfmt interpreter for aarch64
Setting /usr/bin/qemu-aarch64_be-static as binfmt interpreter for aarch64_be
Setting /usr/bin/qemu-hppa-static as binfmt interpreter for hppa
Setting /usr/bin/qemu-riscv32-static as binfmt interpreter for riscv32
Setting /usr/bin/qemu-riscv64-static as binfmt interpreter for riscv64
Setting /usr/bin/qemu-xtensa-static as binfmt interpreter for xtensa
Setting /usr/bin/qemu-xtensaeb-static as binfmt interpreter for xtensaeb
Setting /usr/bin/qemu-microblaze-static as binfmt interpreter for microblaze
Setting /usr/bin/qemu-microblazeel-static as binfmt interpreter for microblazeel
Setting /usr/bin/qemu-or1k-static as binfmt interpreter for or1k
Sending build context to Docker daemon  180.1MB
Step 1/25 : FROM alpine as qemu
 ---> d6e46aa2470d
Step 2/25 : RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/releases/latest/download/qemu-ppc64le-static
 ---> Using cache
 ---> 901c64e5e49b
Step 3/25 : RUN chmod +x /qemu-ppc64le-static
 ---> Using cache
 ---> 29d4e0cadee7
Step 4/25 : FROM golang:1.14.7 as builder
 ---> 0fc73a78e79d
Step 5/25 : ARG GOARCH=ppc64le
 ---> Using cache
 ---> 7d4993e24af5
Step 6/25 : WORKDIR /workspace
 ---> Using cache
 ---> 4cee4ba5c206
Step 7/25 : COPY go.mod go.mod
 ---> Using cache
 ---> 210a3eac5b9e
Step 8/25 : COPY go.sum go.sum
 ---> Using cache
 ---> d862a4033e9d
Step 9/25 : RUN go mod download
 ---> Using cache
 ---> 43d55dbaff02
Step 10/25 : COPY main.go main.go
 ---> Using cache
 ---> 2148e26c78b2
Step 11/25 : COPY api/ api/
 ---> Using cache
 ---> 6074fcba8055
Step 12/25 : COPY controllers/ controllers/
 ---> Using cache
 ---> edd642d788b9
Step 13/25 : COPY version/ version/
 ---> Using cache
 ---> 227aec9e7711
Step 14/25 : RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o manager main.go
 ---> Using cache
 ---> 1b59f1462a5a
Step 15/25 : FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:f5b185532ece6cc482c8424280e2cdccb1b95b735e464ea7aef29dd13c768937
sha256:f5b185532ece6cc482c8424280e2cdccb1b95b735e464ea7aef29dd13c768937: Pulling from ubi8/ubi-minimal
73613623df3a: Pull complete
2738aacb5163: Pull complete
Digest: sha256:f5b185532ece6cc482c8424280e2cdccb1b95b735e464ea7aef29dd13c768937
Status: Downloaded newer image for registry.access.redhat.com/ubi8/ubi-minimal@sha256:f5b185532ece6cc482c8424280e2cdccb1b95b735e464ea7aef29dd13c768937
 ---> 5c94f36a64f7
Step 16/25 : ARG VCS_REF
 ---> Running in f716606712e4
Removing intermediate container f716606712e4
 ---> 70ca7de67342
Step 17/25 : ARG VCS_URL
 ---> Running in 2e7decc1877d
Removing intermediate container 2e7decc1877d
 ---> 14cc8da82f05
Step 18/25 : LABEL org.label-schema.vendor="IBM"   org.label-schema.name="ibm-auditlogging-operator"   org.label-schema.description="IBM Cloud Platform Common Services Audit Logging Component"   org.label-schema.vcs-ref=$VCS_REF   org.label-schema.vcs-url=$VCS_URL   org.label-schema.license="Licensed Materials - Property of IBM"   org.label-schema.schema-version="1.0"   name="ibm-auditlogging-operator"   vendor="IBM"   description="IBM Cloud Platform Common Services Audit Logging Component"   summary="Audit Logging Service that forwards a service's audit logs to a SIEM."
 ---> Running in 41a85b5f0cee
Removing intermediate container 41a85b5f0cee
 ---> 28bfd4b35dbb
Step 19/25 : WORKDIR /
 ---> Running in 68849aec1362
Removing intermediate container 68849aec1362
 ---> db941ef43423
Step 20/25 : COPY --from=builder /workspace/manager .
 ---> 6dc3b019fff5
Step 21/25 : COPY --from=qemu /qemu-ppc64le-static /usr/bin/
 ---> ef3a7011ec95
Step 22/25 : RUN mkdir /licenses
 ---> Running in 25b8bf0faf4c
Removing intermediate container 25b8bf0faf4c
 ---> 8fae51166fde
Step 23/25 : COPY LICENSE /licenses
 ---> 26cddc389403
Step 24/25 : USER 1001
 ---> Running in 44270a1c551c
Removing intermediate container 44270a1c551c
 ---> c39d482e0445
Step 25/25 : ENTRYPOINT ["/manager"]
 ---> Running in 5e98038d4ce8
Removing intermediate container 5e98038d4ce8
 ---> 75155aadbb93
Successfully built 75155aadbb93
Successfully tagged quay.io/hbradfield/ibm-auditlogging-operator-ppc64le:3.8.3
➜  ibm-auditlogging-operator git:(hbradfield-43584) docker inspect 75155aadbb93
[
    {
        "Id": "sha256:75155aadbb93434a648eff49c97c0835511214504cc3740c13f6b2f3f9a56d9a",
        "RepoTags": [
            "quay.io/hbradfield/ibm-auditlogging-operator-ppc64le:3.8.3"
        ],
        "RepoDigests": [],
        "Parent": "sha256:c39d482e0445647b364fdae3216c607d8a29dee991b095fdd9b5511b0135c0b1",
        "Comment": "",
        "Created": "2021-01-05T18:27:33.8163253Z",
        "Container": "5e98038d4ce82586834664fce33dde1ec70fc012988ada09e2083b459a959e0d",
        "ContainerConfig": {
            "Hostname": "bcd52a321152",
            "Domainname": "",
            "User": "1001",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                "container=oci"
            ],
            "Cmd": [
                "/bin/sh",
                "-c",
                "#(nop) ",
                "ENTRYPOINT [\"/manager\"]"
            ],
            "Image": "sha256:c39d482e0445647b364fdae3216c607d8a29dee991b095fdd9b5511b0135c0b1",
            "Volumes": null,
            "WorkingDir": "/",
            "Entrypoint": [
                "/manager"
            ],
            "OnBuild": [],
            "Labels": {
                "architecture": "ppc64le",
                "build-date": "2020-12-10T01:55:49.322769",
                "com.redhat.build-host": "ppc64le-c1-vm-05.prod.osbs.eng.rdu2.redhat.com",
                "com.redhat.component": "ubi8-minimal-container",
                "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
                "description": "IBM Cloud Platform Common Services Audit Logging Component",
                "distribution-scope": "public",
                "io.k8s.description": "The Universal Base Image Minimal is a stripped down image that uses microdnf as a package manager. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
                "io.k8s.display-name": "Red Hat Universal Base Image 8 Minimal",
                "io.openshift.expose-services": "",
                "io.openshift.tags": "minimal rhel8",
                "maintainer": "Red Hat, Inc.",
                "name": "ibm-auditlogging-operator",
                "org.label-schema.description": "IBM Cloud Platform Common Services Audit Logging Component",
                "org.label-schema.license": "Licensed Materials - Property of IBM",
                "org.label-schema.name": "ibm-auditlogging-operator",
                "org.label-schema.schema-version": "1.0",
                "org.label-schema.vcs-ref": "6a7f47d05489efb00ef92ce5b8bb4955b7f41f5a",
                "org.label-schema.vcs-url": "https://github.com/IBM/ibm-auditlogging-operator",
                "org.label-schema.vendor": "IBM",
                "release": "230",
                "summary": "Audit Logging Service that forwards a service's audit logs to a SIEM.",
                "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8-minimal/images/8.3-230",
                "vcs-ref": "c868247d5bda77e997533ece37f1d3816497909e",
                "vcs-type": "git",
                "vendor": "IBM",
                "version": "8.3"
            }
        },
        "DockerVersion": "19.03.13",
        "Author": "",
        "Config": {
            "Hostname": "bcd52a321152",
            "Domainname": "",
            "User": "1001",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                "container=oci"
            ],
            "Cmd": null,
            "Image": "sha256:c39d482e0445647b364fdae3216c607d8a29dee991b095fdd9b5511b0135c0b1",
            "Volumes": null,
            "WorkingDir": "/",
            "Entrypoint": [
                "/manager"
            ],
            "OnBuild": [],
            "Labels": {
                "architecture": "ppc64le",
                "build-date": "2020-12-10T01:55:49.322769",
                "com.redhat.build-host": "ppc64le-c1-vm-05.prod.osbs.eng.rdu2.redhat.com",
                "com.redhat.component": "ubi8-minimal-container",
                "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
                "description": "IBM Cloud Platform Common Services Audit Logging Component",
                "distribution-scope": "public",
                "io.k8s.description": "The Universal Base Image Minimal is a stripped down image that uses microdnf as a package manager. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
                "io.k8s.display-name": "Red Hat Universal Base Image 8 Minimal",
                "io.openshift.expose-services": "",
                "io.openshift.tags": "minimal rhel8",
                "maintainer": "Red Hat, Inc.",
                "name": "ibm-auditlogging-operator",
                "org.label-schema.description": "IBM Cloud Platform Common Services Audit Logging Component",
                "org.label-schema.license": "Licensed Materials - Property of IBM",
                "org.label-schema.name": "ibm-auditlogging-operator",
                "org.label-schema.schema-version": "1.0",
                "org.label-schema.vcs-ref": "6a7f47d05489efb00ef92ce5b8bb4955b7f41f5a",
                "org.label-schema.vcs-url": "https://github.com/IBM/ibm-auditlogging-operator",
                "org.label-schema.vendor": "IBM",
                "release": "230",
                "summary": "Audit Logging Service that forwards a service's audit logs to a SIEM.",
                "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8-minimal/images/8.3-230",
                "vcs-ref": "c868247d5bda77e997533ece37f1d3816497909e",
                "vcs-type": "git",
                "vendor": "IBM",
                "version": "8.3"
            }
        },
        "Architecture": "ppc64le",
        "Os": "linux",
        "Size": 196198447,
        "VirtualSize": 196198447,
        "GraphDriver": {
            "Data": {
                "LowerDir": "/var/lib/docker/overlay2/edee8480c63128f5c311087217975407460c1a61558e0a1494de9fdf998a3201/diff:/var/lib/docker/overlay2/7beab64ead3c1d53d0563548cb0fdbf1e875dc155c62f2fd9db2bc3c55e1fddd/diff:/var/lib/docker/overlay2/c0379ff35ecfe5523a6418d5a18c992575227f38f88594f074a3a56f7e23a6b6/diff:/var/lib/docker/overlay2/48f6d1d5c04bdeb311583148821a5ec4fe3307a8eebddba494b1904e114949c7/diff:/var/lib/docker/overlay2/38c7878c8cf29536a5910046981e3f81ea56cc7de64a924dea8920b34320aca9/diff",
                "MergedDir": "/var/lib/docker/overlay2/dd22b9969892e72e984c09c6d29d7b137468e424d026db82bf9ea5267d5fc739/merged",
                "UpperDir": "/var/lib/docker/overlay2/dd22b9969892e72e984c09c6d29d7b137468e424d026db82bf9ea5267d5fc739/diff",
                "WorkDir": "/var/lib/docker/overlay2/dd22b9969892e72e984c09c6d29d7b137468e424d026db82bf9ea5267d5fc739/work"
            },
            "Name": "overlay2"
        },
        "RootFS": {
            "Type": "layers",
            "Layers": [
                "sha256:e30348fd2918af686d09755a3bfee6e143fcce7284adbddc58699f9895c1009e",
                "sha256:05ec4d30f9e3337374a32ab6ea3e4ac1c4f239f1841c2be49aba3e90482fbf6d",
                "sha256:beb32b1b9ddd1b03541ee2120d8b365631351433df4cf9cdeabeb3b86e09e3dc",
                "sha256:909167f395001ffa7fa7d0d61033bf13a83871d671c379aeed8cbf330758980b",
                "sha256:7c82c606aa0efd675a6622417c2a3f008ad3ad10a8a532b0c925f69b5deb2ef8",
                "sha256:51e3a84f31c667df664a77c2a054453766fd360a1dde2198e1cf8a06ff050bdc"
            ]
        },
        "Metadata": {
            "LastTagTime": "2021-01-05T18:27:33.9631466Z"
        }
    }
]