### PR TITLE
Fix prow build break and version number

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -16,7 +16,7 @@
 
 FROM alpine as qemu
 
-RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/releases/latest/download/qemu-ppc64le-static --progress=dot:giga
+RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/releases/latest/download/qemu-ppc64le-static
 
 RUN chmod +x /qemu-ppc64le-static
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -16,7 +16,7 @@
 
 FROM alpine as qemu
 
-RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/releases/latest/download/qemu-s390x-static --progress=dot:giga
+RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/releases/latest/download/qemu-s390x-static
 
 RUN chmod +x /qemu-s390x-static
 

--- a/bundle/manifests/ibm-auditlogging-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-auditlogging-operator.clusterserviceversion.yaml
@@ -123,10 +123,10 @@ metadata:
     capabilities: Basic Install
     categories: Security
     certified: "false"
-    containerImage: quay.io/opencloudio/ibm-auditlogging-operator:3.10.1
+    containerImage: quay.io/opencloudio/ibm-auditlogging-operator:3.10.0
     createdAt: "2020-10-21T15:30:00Z"
     description: The IBM AuditLogging Operator forwards service audit logs to a configured SIEM.
-    olm.skipRange: '>=3.5.0 <3.10.1'
+    olm.skipRange: '>=3.5.0 <3.10.0'
     operators.operatorframework.io/builder: operator-sdk-v1.0.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
   labels:
@@ -134,7 +134,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: ibm-auditlogging-operator.v3.10.1
+  name: ibm-auditlogging-operator.v3.10.0
   namespace: ibm-common-services
 spec:
   apiservicedefinitions: {}
@@ -312,7 +312,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/opencloudio/ibm-auditlogging-operator:3.10.1
+                image: quay.io/opencloudio/ibm-auditlogging-operator:3.10.0
                 imagePullPolicy: Always
                 name: ibm-auditlogging-operator
                 resources:
@@ -504,4 +504,4 @@ spec:
   provider:
     name: IBM
   replaces: ibm-auditlogging-operator.v3.9.1
-  version: 3.10.1
+  version: 3.10.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,7 +50,7 @@ spec:
         args:
         - --enable-leader-election
         - --metrics-addr=:8383
-        image: quay.io/opencloudio/ibm-auditlogging-operator:3.9.1
+        image: quay.io/opencloudio/ibm-auditlogging-operator:3.10.1
         imagePullPolicy: Always
         env:
           - name: WATCH_NAMESPACE

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,7 +50,7 @@ spec:
         args:
         - --enable-leader-election
         - --metrics-addr=:8383
-        image: quay.io/opencloudio/ibm-auditlogging-operator:3.10.1
+        image: quay.io/opencloudio/ibm-auditlogging-operator:3.10.0
         imagePullPolicy: Always
         env:
           - name: WATCH_NAMESPACE

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 var (
-	Version = "3.10.1"
+	Version = "3.10.0"
 )


### PR DESCRIPTION
Remove the ` --progress=dot:giga` parameter that is currently causing prow builds to break

Additionally, fix up version number to 3.10.0