### PR TITLE
Go version updated to 1.17.7 to fix twistlock issue #51927

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.17.6 as builder
+FROM golang:1.17.7 as builder
 ARG GOARCH=amd64
 
 WORKDIR /workspace

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -21,7 +21,7 @@ RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/r
 RUN chmod +x /qemu-ppc64le-static
 
 # Build the manager binary
-FROM golang:1.17.6 as builder
+FROM golang:1.17.7 as builder
 ARG GOARCH=ppc64le
 
 WORKDIR /workspace

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -21,7 +21,7 @@ RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/rel
 RUN chmod +x /qemu-s390x-static
 
 # Build the manager binary
-FROM golang:1.17.6 as builder
+FROM golang:1.17.7 as builder
 ARG GOARCH=s390x
 
 WORKDIR /workspace


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/51927